### PR TITLE
fix: use plain v-prefix tags, match either tag format in publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Check release was created
         id: check
         run: |
-          TAG=$(git tag --points-at HEAD | grep '^v' | head -1)
+          TAG=$(git tag --points-at HEAD | grep -E '^v|^opencode-llm-proxy-v' | head -1)
           if [ -z "$TAG" ]; then
             echo "No release tag on this commit, skipping publish"
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "packages": {
     ".": {}
   }


### PR DESCRIPTION
Fixes two issues:
- Add `include-component-in-tag: false` to release-please-config.json so future releases use `v1.x.x` tags instead of `opencode-llm-proxy-v1.x.x`
- Update publish.yml tag detection to match either `v*` or `opencode-llm-proxy-v*` (for the already-created v1.1.0 tag)