### PR TITLE
ci: add workflow_dispatch to publish, fetch tags, handle both triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,18 +5,23 @@ on:
     workflows: ["Release Please"]
     types:
       - completed
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref (tag or SHA) to publish"
+        required: true
 
 jobs:
   test:
     name: Test before publish
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -38,7 +43,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.ref || github.event.workflow_run.head_sha }}
+          fetch-tags: true
 
       - name: Check release was created
         id: check


### PR DESCRIPTION
Improvements to publish.yml:
- Add `workflow_dispatch` trigger so publish can be manually re-run (useful for backfilling missed releases like v1.1.0)
- Add `fetch-tags: true` to checkout so `git tag --points-at HEAD` works correctly
- Handle both `workflow_run` and `workflow_dispatch` trigger contexts for checkout ref