### PR TITLE
fix: disable stale bridge tool IDs from other pool slots

### DIFF
--- a/index.js
+++ b/index.js
@@ -511,6 +511,13 @@ function getToolBridgeState() {
     state.toolBridge = {
       freeSlots: Array.from({ length: poolSize }, (_, i) => `px_tools_${i}`),
       waiters: [],
+      // Every bridge tool ID ever registered across the pool's lifetime, from any
+      // slot. Needed because OpenCode has no endpoint to deregister an MCP server,
+      // so a slot reused for a later request stays connected under its old tool
+      // schema until it's next reused - see buildToolsMap() below for why this
+      // must be tracked and explicitly disabled per-turn, not just left out of the
+      // map.
+      knownToolIDs: new Set(),
     }
   }
   return state.toolBridge
@@ -652,7 +659,7 @@ export function applyGeminiToolChoice(tools, toolConfig) {
   return tools
 }
 
-async function registerToolBridge(client, tools) {
+export async function registerToolBridge(client, tools) {
   const slotName = await acquireBridgeSlot()
   const seen = new Set()
   const nameMap = new Map() // full bridge tool ID ("<slot>_<sanitized>") -> original caller-facing name
@@ -684,11 +691,35 @@ async function registerToolBridge(client, tools) {
   })
 
   const toolIDs = bridgeTools.map((tool) => `${slotName}_${tool.name}`)
+  const bridgeState = getToolBridgeState()
+  for (const id of toolIDs) bridgeState.knownToolIDs.add(id)
   return { slotName, toolIDs, nameMap }
 }
 
 function releaseToolBridge(bridge) {
   if (bridge) releaseBridgeSlot(bridge.slotName)
+}
+
+// Builds the per-turn `tools` map sent to OpenCode: the caller's bridge tools enabled,
+// every OpenCode built-in disabled (as before), and - critically - every bridge tool ID
+// ever registered by *any* pool slot explicitly disabled too, then re-enabling only this
+// turn's own IDs.
+//
+// Why this is necessary: OpenCode's server API has no endpoint to deregister an MCP
+// server, so a bridge slot reused for a later request/turn stays connected under its
+// previous tool schema until it's next reused. getDisabledTools() also only snapshots
+// OpenCode's built-in tool IDs once, before any bridge tools exist, so it can never know
+// to disable them either. Without this explicit disable step, a stale, still-connected
+// tool from a previously-used slot remains implicitly enabled and can get called by the
+// model instead of (or alongside) this turn's own tool - the model has no way to tell
+// them apart since both are live MCP tools as far as OpenCode is concerned.
+export function buildToolsMap(baseTools, bridge) {
+  const toolsMap = { ...baseTools }
+  if (!bridge) return toolsMap
+  const bridgeState = getToolBridgeState()
+  for (const id of bridgeState.knownToolIDs) toolsMap[id] = false
+  for (const id of bridge.toolIDs) toolsMap[id] = true
+  return toolsMap
 }
 
 async function runAgentTurn(client, model, messages, system, callerTools, onChunk) {
@@ -698,8 +729,7 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
 
   if (Array.isArray(callerTools) && callerTools.length > 0) {
     bridge = await registerToolBridge(client, callerTools)
-    toolsMap = { ...baseTools }
-    for (const id of bridge.toolIDs) toolsMap[id] = true
+    toolsMap = buildToolsMap(baseTools, bridge)
   }
 
   const session = await client.session.create({ body: { title: `Proxy: ${model.id}` } })

--- a/index.test.js
+++ b/index.test.js
@@ -25,6 +25,8 @@ import {
   applyAnthropicToolChoice,
   parseGeminiTools,
   applyGeminiToolChoice,
+  registerToolBridge,
+  buildToolsMap,
 } from "./index.js"
 
 // ---------------------------------------------------------------------------
@@ -2222,6 +2224,76 @@ test("POST /v1/messages stream: true emits a tool_use content block", async () =
   assert.ok(text.includes("tool_use"))
   assert.ok(text.includes("get_weather"))
   assert.ok(text.includes('"stop_reason":"tool_use"'))
+})
+
+// Regression test for: a bridge slot reused by an earlier turn stays connected under its
+// old tool schema (OpenCode has no MCP deregistration endpoint), and getDisabledTools()
+// only snapshots OpenCode's built-in tool IDs once, before any bridge tools ever exist -
+// so neither mechanism disables a stale, previously-registered bridge tool ID on its own.
+// Without explicitly disabling every previously-seen bridge tool ID per turn, a stale tool
+// from an earlier turn's slot remains implicitly enabled and can be called by the model
+// instead of (or alongside) the current turn's own tool.
+describe("buildToolsMap / registerToolBridge slot isolation", () => {
+  function createMcpMockClient() {
+    const addCalls = []
+    return {
+      client: {
+        mcp: {
+          disconnect: async () => {
+            throw new Error("not connected")
+          },
+          add: async ({ body }) => {
+            addCalls.push(body)
+            return { data: {} }
+          },
+        },
+      },
+      addCalls,
+    }
+  }
+
+  it("disables a previously-registered bridge tool ID from a different pool slot", async () => {
+    const { client } = createMcpMockClient()
+
+    const firstTurnTools = [{ name: "weather_a", description: "", parameters: { type: "object", properties: {} } }]
+    const secondTurnTools = [{ name: "weather_b", description: "", parameters: { type: "object", properties: {} } }]
+
+    // Simulate turn 1: registers a bridge slot and (per the real bug) never gets
+    // explicitly disabled afterwards, since OpenCode can't deregister an MCP server.
+    const bridge1 = await registerToolBridge(client, firstTurnTools)
+    assert.equal(bridge1.toolIDs.length, 1)
+
+    // Simulate turn 2 reusing a *different* slot (mirrors the pool cycling to the next
+    // free slot for a new in-flight request) with its own, different tool.
+    const bridge2 = await registerToolBridge(client, secondTurnTools)
+    assert.equal(bridge2.toolIDs.length, 1)
+    assert.notEqual(
+      bridge1.toolIDs[0],
+      bridge2.toolIDs[0],
+      "test setup assumption: the two turns must land on different bridge tool IDs",
+    )
+
+    const baseTools = { bash: false, read: false, edit: false }
+    const toolsMap = buildToolsMap(baseTools, bridge2)
+
+    // Turn 2's own tool must be enabled.
+    assert.equal(toolsMap[bridge2.toolIDs[0]], true)
+    // Turn 1's stale, still-connected tool must be *explicitly* disabled - not merely
+    // absent from the map, since an absent key left a live MCP tool implicitly enabled
+    // (the actual bug: the model could call it instead of turn 2's own tool).
+    assert.equal(toolsMap[bridge1.toolIDs[0]], false)
+    // OpenCode's built-ins must be untouched.
+    assert.equal(toolsMap.bash, false)
+    assert.equal(toolsMap.read, false)
+    assert.equal(toolsMap.edit, false)
+  })
+
+  it("returns a plain copy of baseTools when there is no bridge for this turn", () => {
+    const baseTools = { bash: false, read: false }
+    const toolsMap = buildToolsMap(baseTools, null)
+    assert.deepEqual(toolsMap, baseTools)
+    assert.notEqual(toolsMap, baseTools, "must be a copy, not the same object")
+  })
 })
 
 test("POST /v1beta/models/:model:generateContent returns a functionCall part", async () => {


### PR DESCRIPTION
## Summary

Closes #55. Fixes a bug where tool/function calling (#52/v1.7.0) can return the *wrong* tool call — a stale one from a previously-reused bridge pool slot — instead of the current turn's own tool.

## The bug

OpenCode's server API has no endpoint to deregister an MCP server once added, so `registerToolBridge()`'s pool of `px_tools_N` slots keeps each slot connected under its *previous* tool schema until that slot is next reused. `getDisabledTools()` also only snapshots OpenCode's built-in tool IDs once, via `client.tool.ids()`, before any bridge tools ever exist — so it can never know about `px_tools_N_*` IDs either, past or present.

The result: `runAgentTurn()` only ever set the *current* turn's own bridge tool IDs to `true` on the shared `tools` map. A previous turn's still-connected tool was never explicitly set to `false` — it was simply absent from the map, which left it implicitly enabled rather than disabled. Once the pool has cycled through more than one slot, a later turn's session can see (and the model can call) an unrelated, stale tool left over from an earlier turn's slot.

Confirmed against a **live** OpenCode server (not just mocks, per the caveat in #52's original PR description): two sequential tool-calling requests with different declared tools (`get_weather`, then `calculate`) — the second request's response contained the *first* request's tool call name instead of its own.

## The fix

- `getToolBridgeState()`: added a `knownToolIDs` set tracking every bridge tool ID ever registered across the pool's lifetime, from any slot.
- `registerToolBridge()`: records each turn's tool IDs into it. Exported for direct unit testing.
- New exported `buildToolsMap(baseTools, bridge)`: explicitly disables *every* known bridge tool ID first, then re-enables only the current turn's own IDs. `runAgentTurn()` now uses this instead of a map that only ever gained `true` entries and never explicitly cleared stale ones.

## Testing

- `npm test` — **140 passed** (138 existing + 2 new)
- `npm run lint` — clean
- Manually verified against a live OpenCode server end-to-end (this wasn't possible when #52 was originally written, per its own notes):
  - Request 1: `tools: [get_weather]` → correctly got back `finish_reason: "tool_calls"`, `function.name: "get_weather"`
  - Request 2 (immediately after, different tool): `tools: [calculate]` → correctly got back `function.name: "calculate"` (not the stale `get_weather`)
  - `GET /mcp` confirmed both `px_tools_0` and `px_tools_1` ended up connected independently, as expected

## Related

- #55 (bug report with the original repro/evidence)
