### PR TITLE
fix: message.part.delta streaming, .info shape for tokens/finish, parts fallback for empty content

### DIFF
--- a/index.js
+++ b/index.js
@@ -776,19 +776,26 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
 
   try {
     for await (const event of stream) {
-      if (event.type === "message.part.updated") {
+      if (event.type === "message.part.delta") {
+        // Real incremental token deltas arrive here, as flat properties (sessionID,
+        // partID, field, delta) - NOT nested under event.properties.part like
+        // message.part.updated below. This is the actual live-streaming source; the
+        // fallback via session.messages() after the loop covers turns where OpenCode
+        // doesn't emit these (see below).
+        const props = event.properties
+        if (
+          props?.sessionID === sessionID &&
+          props?.field === "text" &&
+          typeof props.delta === "string" &&
+          props.delta.length > 0
+        ) {
+          content += props.delta
+          onChunk?.(props.delta)
+        }
+      } else if (event.type === "message.part.updated") {
         const part = event.properties?.part
-        const delta = event.properties?.delta
 
         if (
-          part?.sessionID === sessionID &&
-          part?.type === "text" &&
-          typeof delta === "string" &&
-          delta.length > 0
-        ) {
-          content += delta
-          onChunk?.(delta)
-        } else if (
           toolIDSet &&
           part?.sessionID === sessionID &&
           part?.type === "tool" &&
@@ -826,15 +833,26 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
     throw new Error(errorMessage)
   }
 
+  // Each list item is { info: Message, parts: Part[] } - matching the shape
+  // client.session.prompt() (the non-tool-calling path) already returns directly.
   const messagesResult = await client.session.messages({ path: { id: sessionID } })
-  const assistantMsg = (messagesResult.data ?? []).filter((m) => m.role === "assistant").at(-1)
+  const assistantEntry = (messagesResult.data ?? []).filter((m) => m.info?.role === "assistant").at(-1)
+  const assistantInfo = assistantEntry?.info
+
+  // Fallback for turns where message.part.delta never fired (observed for some
+  // multi-step turns, e.g. continuing a conversation with prior tool calls/results in
+  // history): use the authoritative final text from the fetched message's parts
+  // instead of leaving content empty.
+  if (!content && !toolCall) {
+    content = extractAssistantText(assistantEntry?.parts ?? [])
+  }
 
   return {
     sessionID,
     content,
     toolCall,
-    tokens: assistantMsg?.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-    finish: toolCall ? "tool_calls" : assistantMsg?.finish,
+    tokens: assistantInfo?.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    finish: toolCall ? "tool_calls" : assistantInfo?.finish,
   }
 }
 

--- a/index.test.js
+++ b/index.test.js
@@ -78,9 +78,12 @@ function createStreamingClient(chunks) {
       messages: async () => ({
         data: [
           {
-            role: "assistant",
-            tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
-            finish: "end_turn",
+            info: {
+              role: "assistant",
+              tokens: { input: 10, output: 5, reasoning: 0, cache: { read: 0, write: 0 } },
+              finish: "end_turn",
+            },
+            parts: [],
           },
         ],
       }),
@@ -337,16 +340,18 @@ test("missing messages field returns 400", async () => {
 test("stream: true returns SSE response", async () => {
   const events = [
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: "Hello",
       },
     },
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: " world",
       },
     },
@@ -1094,16 +1099,18 @@ test("POST /v1/responses instructions field is incorporated", async () => {
 test("POST /v1/responses stream: true returns SSE lifecycle events", async () => {
   const events = [
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: "The answer",
       },
     },
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: " is 42.",
       },
     },
@@ -1137,16 +1144,18 @@ test("POST /v1/responses stream: true returns SSE lifecycle events", async () =>
 test("POST /v1/responses stream: true emits content_part.done with accumulated text per OpenAI spec", async () => {
   const events = [
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: "The answer",
       },
     },
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: " is 42.",
       },
     },
@@ -1635,16 +1644,18 @@ test("POST /v1/messages malformed JSON returns 400", async () => {
 test("POST /v1/messages stream: true returns Anthropic SSE events", async () => {
   const events = [
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: "Hello",
       },
     },
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: " world",
       },
     },
@@ -1832,16 +1843,18 @@ test("POST /v1beta/models/:model:generateContent malformed JSON returns 400", as
 test("POST /v1beta/models/:model:streamGenerateContent returns NDJSON stream", async () => {
   const events = [
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: "Gem",
       },
     },
     {
-      type: "message.part.updated",
+      type: "message.part.delta",
       properties: {
-        part: { sessionID: "sess-123", type: "text" },
+        sessionID: "sess-123",
+        field: "text",
         delta: "ini",
       },
     },
@@ -2099,9 +2112,12 @@ function createToolCallClient({ toolName, toolArgs, callID = "call_1", finish = 
       messages: async () => ({
         data: [
           {
-            role: "assistant",
-            tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
-            finish,
+            info: {
+              role: "assistant",
+              tokens: { input: 5, output: 2, reasoning: 0, cache: { read: 0, write: 0 } },
+              finish,
+            },
+            parts: [],
           },
         ],
       }),
@@ -2226,6 +2242,126 @@ test("POST /v1/messages stream: true emits a tool_use content block", async () =
   assert.ok(text.includes("tool_use"))
   assert.ok(text.includes("get_weather"))
   assert.ok(text.includes('"stop_reason":"tool_use"'))
+})
+
+// Regression test for: OpenCode delivers real incremental streaming text via
+// message.part.delta events (flat properties: sessionID, partID, field, delta) - a
+// completely separate event type from message.part.updated, which only carries status/
+// snapshot updates (used here for tool-call detection). For some turns (observed with a
+// multi-message conversation history, e.g. continuing after a prior tool call/result),
+// OpenCode never emits message.part.delta at all for the final reply - only
+// message.part.updated snapshots - so relying on message.part.delta alone would silently
+// produce empty content. The fallback: after the loop, fetch the session's messages
+// (client.session.messages()) and extract the final text from the assistant message's
+// parts array directly, exactly as the non-tool-calling path already does via
+// extractAssistantText().
+//
+// Each list item from client.session.messages() is `{ info: Message, parts: Part[] }` -
+// info.role/info.tokens/info.finish, NOT flat role/tokens/finish directly on the item.
+function createToolAwareTextClient({ events, assistantParts, tokens, finish }) {
+  return {
+    app: { log: async () => {} },
+    tool: { ids: async () => ({ data: [] }) },
+    config: {
+      providers: async () => ({
+        data: { providers: [{ id: "openai", models: { "gpt-4o": { id: "gpt-4o", name: "GPT-4o" } } }] },
+      }),
+    },
+    mcp: {
+      disconnect: async () => {
+        throw new Error("not connected")
+      },
+      add: async () => ({ data: {} }),
+    },
+    session: {
+      create: async () => ({ data: { id: "sess-text-1" } }),
+      promptAsync: async () => {},
+      abort: async () => ({ data: true }),
+      messages: async () => ({
+        data: [
+          {
+            info: { role: "assistant", tokens, finish },
+            parts: assistantParts,
+          },
+        ],
+      }),
+    },
+    event: {
+      subscribe: async () => ({
+        stream: (async function* () {
+          for (const event of events) yield event
+        })(),
+      }),
+    },
+  }
+}
+
+test("POST /v1/chat/completions falls back to the final message's parts when message.part.delta never fires", async () => {
+  const client = createToolAwareTextClient({
+    events: [{ type: "session.idle", properties: { sessionID: "sess-text-1" } }],
+    assistantParts: [{ type: "step-start" }, { type: "text", text: "Agentic AI startups raise record funding" }],
+    tokens: { input: 42, output: 7, reasoning: 0, cache: { read: 0, write: 0 } },
+    finish: "stop",
+  })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      messages: [
+        { role: "user", content: "Search the web then summarize." },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [{ id: "call_1", type: "function", function: { name: "search", arguments: "{}" } }],
+        },
+        { role: "tool", tool_call_id: "call_1", content: "some search result" },
+      ],
+      tools: [{ type: "function", function: { name: "search" } }],
+    }),
+  })
+
+  const response = await handler(request)
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(body.choices[0].message.content, "Agentic AI startups raise record funding")
+  assert.equal(body.choices[0].finish_reason, "stop")
+  // Also locks in the .info.tokens fix - these were always read as undefined (silently
+  // falling back to all-zero usage) before, since the flat .tokens field this code used
+  // to read doesn't exist on the real API's { info, parts } shape.
+  assert.equal(body.usage.prompt_tokens, 42)
+  assert.equal(body.usage.completion_tokens, 7)
+})
+
+test("POST /v1/chat/completions accumulates content from message.part.delta events", async () => {
+  const client = createToolAwareTextClient({
+    events: [
+      { type: "message.part.delta", properties: { sessionID: "sess-text-1", field: "text", delta: "Hello" } },
+      { type: "message.part.delta", properties: { sessionID: "sess-text-1", field: "text", delta: " world" } },
+      { type: "session.idle", properties: { sessionID: "sess-text-1" } },
+    ],
+    assistantParts: [{ type: "text", text: "Hello world" }],
+    tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+    finish: "stop",
+  })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "Say hello world." }],
+      tools: [{ type: "function", function: { name: "search" } }],
+    }),
+  })
+
+  const response = await handler(request)
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(body.choices[0].message.content, "Hello world")
 })
 
 // Regression test for: a bridge slot reused by an earlier turn stays connected under its


### PR DESCRIPTION
## Summary

Found and fixed three compounding bugs in `runAgentTurn()` while testing real multi-turn tool-calling conversations (continuing after a prior tool call/result in history) against a live OpenCode server. None of these were caught by the existing unit tests, since their mocks happened to match the same wrong assumptions as the code they were testing.

## The bugs

1. **Real incremental streaming text arrives via `message.part.delta`** - a completely separate event type with flat properties (`sessionID`, `partID`, `field`, `delta`) - not via `event.properties.delta` on `message.part.updated`, which is all the code listened to. `message.part.updated` only ever carries status/snapshot updates (confirmed still correct and unchanged for tool-call detection).
2. **`client.session.messages()` returns items shaped like `{ info: Message, parts: Part[] }`** - matching what `client.session.prompt()` (the non-tool-calling path) already returns, and what `extractAssistantText()` already expects - not a flat `{ role, tokens, finish, ... }` shape. Reading `assistantMsg.role`/`.tokens`/`.finish` directly meant the role filter never matched anything, so **token usage silently always fell back to all-zero, and `finish` was always `undefined`, for every single tool-calling request** - not just the scenario below.
3. **For some turns, OpenCode never emits `message.part.delta` at all for the final reply** - only `message.part.updated` snapshots on the same part id. Observed specifically when continuing a conversation with prior tool calls/results in history - i.e. real multi-step agentic tool use, not simple one-shot prompts. Content stayed permanently empty in exactly this case: not a hypothetical edge case, but the core "read a tool result and continue" pattern any real tool-using agent depends on.

## Repro

```bash
curl http://127.0.0.1:4010/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "github-copilot/claude-sonnet-5",
    "messages": [
      {"role": "user", "content": "Search the web for one recent headline about agentic AI, then give me just the headline."},
      {"role": "assistant", "content": null, "tool_calls": [{"id":"call_1","type":"function","function":{"name":"search","arguments":"{\"query\":\"agentic AI news\"}"}}]},
      {"role": "tool", "tool_call_id": "call_1", "content": "Title: \"Agentic AI startups raise record funding in 2026\" - TechCrunch."}
    ],
    "tools": [
      {"type":"function","function":{"name":"search","description":"Search the web","parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}}},
      {"type":"function","function":{"name":"format_final_json_response","description":"Final answer","parameters":{"type":"object","properties":{"output":{"type":"string"}}}}}
    ]
  }'
```

**Before:** `{"finish_reason":"stop","message":{"role":"assistant","content":""}}`, `"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}` (always zero)
**After:** `{"finish_reason":"stop","message":{"role":"assistant","content":"\"Agentic AI startups raise record funding in 2026\""}}`, `"usage":{"prompt_tokens":2,"completion_tokens":21,"total_tokens":23}`

## The fix

- `runAgentTurn()` now handles `message.part.delta` for real-time `onChunk`/content accumulation (fixes streaming + the common case)
- Reads `tokens`/`finish` from `assistantEntry.info` instead of the item directly (fixes usage always being zero and `finish` always being `undefined` on natural, non-tool-call completions)
- Falls back to `extractAssistantText(assistantEntry.parts)` for the final content when the live stream produced nothing, reusing the same helper the non-tool-calling path already relies on (fixes empty content on multi-step turns)

## Test changes

- Fixed `createToolCallClient`/`createStreamingClient`'s `session.messages` mock to the real `{ info, parts }` shape (previously flat, matching the bug rather than the real API - all 9 dependent tests still pass since none asserted specific token values, but they're now actually exercising correct behavior)
- Converted all `message.part.updated`+`delta` text-streaming events in existing tests to `message.part.delta`, matching the corrected event handling
- Two new tests: accumulating content from `message.part.delta` events, and falling back to the message's parts (plus reading real tokens/finish from `.info`) when `message.part.delta` never fires

## Testing

- `npm test` - **143 passed** (141 + 2 new)
- `npm run lint` - clean
- Manually verified against a live OpenCode server end-to-end (see repro above) - confirmed both the content and token-usage fixes work correctly together

## Related

- Builds on #56/#58 (tool-calling slot isolation + review follow-ups)
