### PR TITLE
feat: parallel tool calls across OpenAI, Anthropic, and Gemini APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/KochC/opencode-llm-proxy/actions/workflows/ci.yml/badge.svg)](https://github.com/KochC/opencode-llm-proxy/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-**One local endpoint. Every model you have access to. Any API format. Tool calling included.**
+**One local endpoint. Every model you have access to. Any API format. Parallel tool calling included.**
 
 opencode-llm-proxy is an [OpenCode](https://opencode.ai) plugin that starts a local HTTP server on `http://127.0.0.1:4010`. It translates between the API format your tool speaks and whichever LLM provider OpenCode has configured — so you never reconfigure the same models twice.
 
@@ -28,7 +28,7 @@ Your tool (OpenAI / Anthropic / Gemini SDK, coding agent, etc.)
 | Anthropic Messages API | `POST /v1/messages` |
 | Google Gemini | `POST /v1beta/models/:model:generateContent` |
 
-**✨ Tool calling works with all four formats** — point a coding agent (Claude Code, Cursor, Continue, Cline, your own agent loop, ...) at the proxy and its `tools`/`tool_choice` calls are translated through to whatever model OpenCode has configured, with a real `tool_calls` / `tool_use` / `functionCall` response handed back. See [Tool calling](#tool-calling).
+**✨ Tool calling works with all four formats — including parallel tool calls.** Point a coding agent (Claude Code, Cursor, Continue, Cline, your own agent loop, ...) at the proxy and its `tools`/`tool_choice` calls are translated through to whatever model OpenCode has configured, with a real `tool_calls` / `tool_use` / `functionCall` response handed back — one call or **several in a single turn**. See [Tool calling](#tool-calling).
 
 ---
 
@@ -197,17 +197,37 @@ curl http://127.0.0.1:4010/v1/chat/completions \
 
 Send the tool's result back on your next request (`role: "tool"` / `tool_result` / `functionResponse`, per your API's convention) alongside the full conversation history, same as any other multi-turn request — the proxy is stateless between calls either way.
 
+### Parallel tool calls
+
+When the model decides to call several tools at once, you get **all of them back in a single response** — a `tool_calls` array (OpenAI), multiple `tool_use` blocks (Anthropic), or multiple `functionCall` parts (Gemini), streaming or not. Ask a model for the weather in Paris *and* Tokyo and you'll get two fully-formed calls with their own IDs and arguments, ready to execute in parallel:
+
+```json
+{
+  "choices": [{
+    "finish_reason": "tool_calls",
+    "message": {
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        { "id": "call_1", "type": "function", "function": { "name": "get_weather", "arguments": "{\"city\":\"Paris\"}" } },
+        { "id": "call_2", "type": "function", "function": { "name": "get_weather", "arguments": "{\"city\":\"Tokyo\"}" } }
+      ]
+    }
+  }]
+}
+```
+
 ### How tool calling works under the hood
 
 OpenCode's own agent loop always executes tools itself, server-side, so there's no native concept of a "client-executed" tool call to hand off to. To bridge that gap, when a request includes `tools`:
 
 1. The proxy dynamically registers a small local [MCP](https://opencode.ai/docs/mcp-servers/) server whose tool list is exactly your declared tool schemas (see `mcp-tool-bridge.js`).
 2. Only those tools are enabled for that one prompt call — every built-in OpenCode tool stays disabled, same as always.
-3. As soon as the model proposes calling one of your tools, the proxy immediately aborts the OpenCode session (before the bridge's no-op handler is ever consulted) and translates the captured call name + arguments into your API's tool-call shape — `tool_calls` (OpenAI), `tool_use` (Anthropic), or a `functionCall` part (Gemini) — instead of a text answer.
+3. The proxy watches OpenCode's live event stream and captures every tool call the model proposes in that turn — with its fully-populated arguments — then aborts the session the moment the tool-calling step finishes, before OpenCode acts on the bridge's no-op results. The captured calls are translated into your API's tool-call shape — `tool_calls` (OpenAI), `tool_use` (Anthropic), or `functionCall` parts (Gemini) — instead of a text answer.
 
 ### Notes and current limitations
 
-- One tool call per turn — parallel/multiple simultaneous tool calls aren't supported.
+- Parallel tool calls in a single turn are fully supported across all four API formats (streaming and non-streaming).
 - `tool_choice: "none"` (OpenAI/Gemini `mode: "NONE"`/Anthropic `type: "none"`) disables tool calling for that request; forcing a specific named tool is supported.
 - Bridge servers are reused from a small fixed-size pool (`px_tools_0`, `px_tools_1`, ...) rather than registered fresh per request, since OpenCode's server API has no endpoint to deregister an MCP server once added. Configure the pool size with `OPENCODE_LLM_PROXY_TOOL_BRIDGE_POOL_SIZE` (default `8`) if you expect more than 8 concurrent in-flight tool-calling requests.
 - The bridge process is spawned with `node`, so `node` must be on `PATH` wherever OpenCode is running.
@@ -450,7 +470,7 @@ Streaming uses OpenCode's `client.event.subscribe()` SSE stream. Text deltas are
 - Text only — image, audio, and file inputs are ignored
 - No cross-request session state — send full conversation history on every request
 - Temperature and max tokens are advisory (passed as system prompt hints)
-- Tool calling supports one call per turn — see [Tool calling](#tool-calling) above
+- Tool calling supports parallel calls in a single turn — see [Tool calling](#tool-calling) above
 
 ---
 

--- a/index.js
+++ b/index.js
@@ -275,7 +275,7 @@ async function executePrompt(client, request, model, messages, system, callerToo
     const result = await runAgentTurn(client, model, messages, system, callerTools, () => {})
     return {
       content: result.content,
-      toolCall: result.toolCall,
+      toolCalls: result.toolCalls,
       request,
       sessionID: result.sessionID,
       completion: {
@@ -324,7 +324,7 @@ async function executePrompt(client, request, model, messages, system, callerToo
 
   return {
     content,
-    toolCall: null,
+    toolCalls: [],
     completion,
     request,
     sessionID: session.data.id,
@@ -337,7 +337,7 @@ async function executePromptStreaming(client, model, messages, system, onChunk, 
     sessionID: result.sessionID,
     tokens: result.tokens,
     finish: result.finish,
-    toolCall: result.toolCall,
+    toolCalls: result.toolCalls,
   }
 }
 
@@ -346,25 +346,25 @@ function createChatCompletionResponse(result, model) {
   const tokensIn = result.completion.data.info?.tokens?.input ?? 0
   const tokensOut = result.completion.data.info?.tokens?.output ?? 0
 
-  const message = result.toolCall
-    ? {
-        role: "assistant",
-        content: null,
-        tool_calls: [
-          {
-            id: result.toolCall.id,
+  const toolCalls = result.toolCalls ?? []
+  const message =
+    toolCalls.length > 0
+      ? {
+          role: "assistant",
+          content: null,
+          tool_calls: toolCalls.map((call) => ({
+            id: call.id,
             type: "function",
             function: {
-              name: result.toolCall.name,
-              arguments: JSON.stringify(result.toolCall.arguments ?? {}),
+              name: call.name,
+              arguments: JSON.stringify(call.arguments ?? {}),
             },
-          },
-        ],
-      }
-    : {
-        role: "assistant",
-        content: result.content,
-      }
+          })),
+        }
+      : {
+          role: "assistant",
+          content: result.content,
+        }
 
   return {
     id: `chatcmpl_${crypto.randomUUID().replace(/-/g, "")}`,
@@ -374,7 +374,7 @@ function createChatCompletionResponse(result, model) {
     choices: [
       {
         index: 0,
-        finish_reason: result.toolCall ? "tool_calls" : mapFinishReason(result.completion.data.info?.finish),
+        finish_reason: toolCalls.length > 0 ? "tool_calls" : mapFinishReason(result.completion.data.info?.finish),
         message,
       },
     ],
@@ -390,32 +390,32 @@ function createResponsesApiResponse(result, model) {
   const tokensIn = result.completion.data.info?.tokens?.input ?? 0
   const tokensOut = result.completion.data.info?.tokens?.output ?? 0
 
-  const output = result.toolCall
-    ? [
-        {
+  const toolCalls = result.toolCalls ?? []
+  const output =
+    toolCalls.length > 0
+      ? toolCalls.map((call) => ({
           id: `fc_${crypto.randomUUID().replace(/-/g, "")}`,
           type: "function_call",
-          call_id: result.toolCall.id,
-          name: result.toolCall.name,
-          arguments: JSON.stringify(result.toolCall.arguments ?? {}),
+          call_id: call.id,
+          name: call.name,
+          arguments: JSON.stringify(call.arguments ?? {}),
           status: "completed",
-        },
-      ]
-    : [
-        {
-          id: `msg_${crypto.randomUUID().replace(/-/g, "")}`,
-          type: "message",
-          status: "completed",
-          role: "assistant",
-          content: [
-            {
-              type: "output_text",
-              text: result.content,
-              annotations: [],
-            },
-          ],
-        },
-      ]
+        }))
+      : [
+          {
+            id: `msg_${crypto.randomUUID().replace(/-/g, "")}`,
+            type: "message",
+            status: "completed",
+            role: "assistant",
+            content: [
+              {
+                type: "output_text",
+                text: result.content,
+                annotations: [],
+              },
+            ],
+          },
+        ]
 
   return {
     id: `resp_${crypto.randomUUID().replace(/-/g, "")}`,
@@ -424,8 +424,8 @@ function createResponsesApiResponse(result, model) {
     status: "completed",
     model: model.id,
     output,
-    output_text: result.toolCall ? "" : result.content,
-    parallel_tool_calls: false,
+    output_text: toolCalls.length > 0 ? "" : result.content,
+    parallel_tool_calls: true,
     reasoning: {
       effort: result.request.reasoning?.effort ?? null,
       summary: null,
@@ -772,7 +772,37 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
 
   let errorMessage = null
   let content = ""
-  let toolCall = null
+  // Tool calls collected live off the event stream, keyed by callID so parallel calls
+  // and the pending -> running -> completed status updates for each collapse into one
+  // entry. session.messages() does NOT carry the tool parts in current OpenCode, so the
+  // live stream is the authoritative source here.
+  const toolCallsByID = new Map()
+  // The assistant message that carries this turn's tool calls. Once set, we only accept
+  // tool parts (and the terminating step-finish) from this same message, so a follow-up
+  // agent step can never leak spurious calls into the result.
+  let toolMessageID = null
+
+  const recordToolPart = (part) => {
+    const callID = part.callID
+    if (!callID) return
+    const input = part.state?.input
+    const hasInput =
+      input && typeof input === "object" && !Array.isArray(input) && Object.keys(input).length > 0
+    const existing = toolCallsByID.get(callID)
+    if (!existing) {
+      toolCallsByID.set(callID, {
+        id: callID,
+        name: bridge.nameMap.get(part.tool) ?? part.tool,
+        arguments: hasInput ? input : {},
+        hasInput: Boolean(hasInput),
+      })
+    } else if (hasInput && !existing.hasInput) {
+      // Upgrade from the empty-input "pending" snapshot to the populated one that
+      // arrives with "running"/"completed".
+      existing.arguments = input
+      existing.hasInput = true
+    }
+  }
 
   try {
     for await (const event of stream) {
@@ -794,19 +824,27 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
         }
       } else if (event.type === "message.part.updated") {
         const part = event.properties?.part
+        if (!part || part.sessionID !== sessionID) continue
 
         if (
           toolIDSet &&
-          part?.sessionID === sessionID &&
-          part?.type === "tool" &&
+          part.type === "tool" &&
           toolIDSet.has(part.tool) &&
-          (part.state?.status === "pending" || part.state?.status === "running")
+          (!toolMessageID || part.messageID === toolMessageID)
         ) {
-          toolCall = {
-            id: part.callID,
-            name: bridge.nameMap.get(part.tool) ?? part.tool,
-            arguments: part.state.input ?? {},
-          }
+          // A bridge tool call. Input is empty on "pending" and only populated on
+          // "running"/"completed", so we keep updating until we have the arguments.
+          if (part.messageID) toolMessageID = part.messageID
+          recordToolPart(part)
+        } else if (
+          part.type === "step-finish" &&
+          toolCallsByID.size > 0 &&
+          (!toolMessageID || part.messageID === toolMessageID)
+        ) {
+          // The tool-calling step is complete: every tool call in this assistant
+          // message (including parallel ones) has now been observed with its arguments.
+          // Abort before OpenCode runs a follow-up step on the placeholder bridge
+          // results (which would waste tokens and could emit spurious calls).
           try {
             await client.session.abort({ path: { id: sessionID } })
           } catch {
@@ -829,7 +867,13 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
     releaseToolBridge(bridge)
   }
 
-  if (errorMessage && !toolCall) {
+  const toolCalls = [...toolCallsByID.values()].map((call) => ({
+    id: call.id,
+    name: call.name,
+    arguments: call.arguments ?? {},
+  }))
+
+  if (errorMessage && toolCalls.length === 0) {
     throw new Error(errorMessage)
   }
 
@@ -843,16 +887,16 @@ async function runAgentTurn(client, model, messages, system, callerTools, onChun
   // multi-step turns, e.g. continuing a conversation with prior tool calls/results in
   // history): use the authoritative final text from the fetched message's parts
   // instead of leaving content empty.
-  if (!content && !toolCall) {
+  if (!content && toolCalls.length === 0) {
     content = extractAssistantText(assistantEntry?.parts ?? [])
   }
 
   return {
     sessionID,
     content,
-    toolCall,
+    toolCalls,
     tokens: assistantInfo?.tokens ?? { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-    finish: toolCall ? "tool_calls" : assistantInfo?.finish,
+    finish: toolCalls.length > 0 ? "tool_calls" : assistantInfo?.finish,
   }
 }
 
@@ -1058,16 +1102,16 @@ export function mapFinishReasonToAnthropic(finish) {
 function createAnthropicResponse(result, model) {
   const tokensIn = result.completion.data.info?.tokens?.input ?? 0
   const tokensOut = result.completion.data.info?.tokens?.output ?? 0
-  const content = result.toolCall
-    ? [
-        {
+  const toolCalls = result.toolCalls ?? []
+  const content =
+    toolCalls.length > 0
+      ? toolCalls.map((call) => ({
           type: "tool_use",
-          id: result.toolCall.id,
-          name: result.toolCall.name,
-          input: result.toolCall.arguments ?? {},
-        },
-      ]
-    : [{ type: "text", text: result.content }]
+          id: call.id,
+          name: call.name,
+          input: call.arguments ?? {},
+        }))
+      : [{ type: "text", text: result.content }]
 
   return {
     id: `msg_${crypto.randomUUID().replace(/-/g, "")}`,
@@ -1075,7 +1119,7 @@ function createAnthropicResponse(result, model) {
     role: "assistant",
     content,
     model: model.id,
-    stop_reason: result.toolCall ? "tool_use" : mapFinishReasonToAnthropic(result.completion.data.info?.finish),
+    stop_reason: toolCalls.length > 0 ? "tool_use" : mapFinishReasonToAnthropic(result.completion.data.info?.finish),
     stop_sequence: null,
     usage: { input_tokens: tokensIn, output_tokens: tokensOut },
   }
@@ -1148,10 +1192,12 @@ export function mapFinishReasonToGemini(finish) {
   return "STOP"
 }
 
-function createGeminiResponse(content, finish, tokens, toolCall) {
-  const parts = toolCall
-    ? [{ functionCall: { name: toolCall.name, args: toolCall.arguments ?? {} } }]
-    : [{ text: content }]
+function createGeminiResponse(content, finish, tokens, toolCalls) {
+  const calls = toolCalls ?? []
+  const parts =
+    calls.length > 0
+      ? calls.map((call) => ({ functionCall: { name: call.name, args: call.arguments ?? {} } }))
+      : [{ text: content }]
 
   return {
     candidates: [
@@ -1265,7 +1311,8 @@ export function createProxyFetchHandler(client) {
             callerTools,
           )
             .then((streamResult) => {
-              if (streamResult.toolCall) {
+              const toolCalls = streamResult.toolCalls ?? []
+              if (toolCalls.length > 0) {
                 const toolCallChunk = JSON.stringify({
                   id: completionID,
                   object: "chat.completion.chunk",
@@ -1276,17 +1323,15 @@ export function createProxyFetchHandler(client) {
                       index: 0,
                       delta: {
                         role: "assistant",
-                        tool_calls: [
-                          {
-                            index: 0,
-                            id: streamResult.toolCall.id,
-                            type: "function",
-                            function: {
-                              name: streamResult.toolCall.name,
-                              arguments: JSON.stringify(streamResult.toolCall.arguments ?? {}),
-                            },
+                        tool_calls: toolCalls.map((call, index) => ({
+                          index,
+                          id: call.id,
+                          type: "function",
+                          function: {
+                            name: call.name,
+                            arguments: JSON.stringify(call.arguments ?? {}),
                           },
-                        ],
+                        })),
                       },
                       finish_reason: null,
                     },
@@ -1304,7 +1349,7 @@ export function createProxyFetchHandler(client) {
                   {
                     index: 0,
                     delta: {},
-                    finish_reason: streamResult.toolCall ? "tool_calls" : mapFinishReason(streamResult.finish),
+                    finish_reason: toolCalls.length > 0 ? "tool_calls" : mapFinishReason(streamResult.finish),
                   },
                 ],
                 usage: {
@@ -1462,53 +1507,58 @@ export function createProxyFetchHandler(client) {
             callerTools,
           )
             .then((streamResult) => {
-              if (streamResult.toolCall) {
-                const args = JSON.stringify(streamResult.toolCall.arguments ?? {})
-                const callItemID = `fc_${crypto.randomUUID().replace(/-/g, "")}`
-                queue.enqueue(
-                  sseEvent("response.output_item.added", {
-                    type: "response.output_item.added",
-                    output_index: 0,
-                    item: {
-                      id: callItemID,
-                      type: "function_call",
-                      status: "in_progress",
-                      call_id: streamResult.toolCall.id,
-                      name: streamResult.toolCall.name,
-                      arguments: "",
-                    },
-                  }),
-                )
-                queue.enqueue(
-                  sseEvent("response.function_call_arguments.delta", {
-                    type: "response.function_call_arguments.delta",
-                    item_id: callItemID,
-                    output_index: 0,
-                    delta: args,
-                  }),
-                )
-                queue.enqueue(
-                  sseEvent("response.function_call_arguments.done", {
-                    type: "response.function_call_arguments.done",
-                    item_id: callItemID,
-                    output_index: 0,
-                    arguments: args,
-                  }),
-                )
-                queue.enqueue(
-                  sseEvent("response.output_item.done", {
-                    type: "response.output_item.done",
-                    output_index: 0,
-                    item: {
-                      id: callItemID,
-                      type: "function_call",
-                      status: "completed",
-                      call_id: streamResult.toolCall.id,
-                      name: streamResult.toolCall.name,
+              const toolCalls = streamResult.toolCalls ?? []
+              if (toolCalls.length > 0) {
+                // Each parallel tool call is its own output item with a distinct output_index.
+                toolCalls.forEach((call, index) => {
+                  const args = JSON.stringify(call.arguments ?? {})
+                  const callItemID = `fc_${crypto.randomUUID().replace(/-/g, "")}`
+                  const outputIndex = index + 1
+                  queue.enqueue(
+                    sseEvent("response.output_item.added", {
+                      type: "response.output_item.added",
+                      output_index: outputIndex,
+                      item: {
+                        id: callItemID,
+                        type: "function_call",
+                        status: "in_progress",
+                        call_id: call.id,
+                        name: call.name,
+                        arguments: "",
+                      },
+                    }),
+                  )
+                  queue.enqueue(
+                    sseEvent("response.function_call_arguments.delta", {
+                      type: "response.function_call_arguments.delta",
+                      item_id: callItemID,
+                      output_index: outputIndex,
+                      delta: args,
+                    }),
+                  )
+                  queue.enqueue(
+                    sseEvent("response.function_call_arguments.done", {
+                      type: "response.function_call_arguments.done",
+                      item_id: callItemID,
+                      output_index: outputIndex,
                       arguments: args,
-                    },
-                  }),
-                )
+                    }),
+                  )
+                  queue.enqueue(
+                    sseEvent("response.output_item.done", {
+                      type: "response.output_item.done",
+                      output_index: outputIndex,
+                      item: {
+                        id: callItemID,
+                        type: "function_call",
+                        status: "completed",
+                        call_id: call.id,
+                        name: call.name,
+                        arguments: args,
+                      },
+                    }),
+                  )
+                })
                 queue.enqueue(
                   sseEvent("response.completed", {
                     type: "response.completed",
@@ -1716,23 +1766,29 @@ export function createProxyFetchHandler(client) {
             callerTools,
           )
             .then((streamResult) => {
-              if (streamResult.toolCall) {
+              const toolCalls = streamResult.toolCalls ?? []
+              if (toolCalls.length > 0) {
                 if (textBlockStarted) {
                   queue.enqueue(sseEvent("content_block_stop", { type: "content_block_stop", index: 0 }))
                 }
-                const blockIndex = textBlockStarted ? 1 : 0
-                const argsJson = JSON.stringify(streamResult.toolCall.arguments ?? {})
-                queue.enqueue(sseEvent("content_block_start", {
-                  type: "content_block_start",
-                  index: blockIndex,
-                  content_block: { type: "tool_use", id: streamResult.toolCall.id, name: streamResult.toolCall.name, input: {} },
-                }))
-                queue.enqueue(sseEvent("content_block_delta", {
-                  type: "content_block_delta",
-                  index: blockIndex,
-                  delta: { type: "input_json_delta", partial_json: argsJson },
-                }))
-                queue.enqueue(sseEvent("content_block_stop", { type: "content_block_stop", index: blockIndex }))
+                // Each parallel tool call is a separate tool_use content block. Block
+                // indexes follow the (optional) leading text block at index 0.
+                const baseIndex = textBlockStarted ? 1 : 0
+                toolCalls.forEach((call, i) => {
+                  const blockIndex = baseIndex + i
+                  const argsJson = JSON.stringify(call.arguments ?? {})
+                  queue.enqueue(sseEvent("content_block_start", {
+                    type: "content_block_start",
+                    index: blockIndex,
+                    content_block: { type: "tool_use", id: call.id, name: call.name, input: {} },
+                  }))
+                  queue.enqueue(sseEvent("content_block_delta", {
+                    type: "content_block_delta",
+                    index: blockIndex,
+                    delta: { type: "input_json_delta", partial_json: argsJson },
+                  }))
+                  queue.enqueue(sseEvent("content_block_stop", { type: "content_block_stop", index: blockIndex }))
+                })
                 queue.enqueue(sseEvent("message_delta", {
                   type: "message_delta",
                   delta: { stop_reason: "tool_use", stop_sequence: null },
@@ -1850,9 +1906,10 @@ export function createProxyFetchHandler(client) {
             callerTools,
           )
             .then((streamResult) => {
+              const toolCalls = streamResult.toolCalls ?? []
               const finalChunk = JSON.stringify(
-                streamResult.toolCall
-                  ? createGeminiResponse("", streamResult.finish, streamResult.tokens, streamResult.toolCall)
+                toolCalls.length > 0
+                  ? createGeminiResponse("", streamResult.finish, streamResult.tokens, toolCalls)
                   : createGeminiResponse("", streamResult.finish, streamResult.tokens),
               )
               queue.enqueue(finalChunk + "\n")
@@ -1901,7 +1958,7 @@ export function createProxyFetchHandler(client) {
         const result = await executePrompt(client, body, model, messages, system, callerTools)
         const finish = result.completion.data.info?.finish
         const tokens = result.completion.data.info?.tokens
-        return json(createGeminiResponse(result.content, finish, tokens, result.toolCall), 200, {}, request)
+        return json(createGeminiResponse(result.content, finish, tokens, result.toolCalls), 200, {}, request)
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error)
         await safeLog(client, "error", "Gemini proxy call failed", { error: message, requestedModel: geminiModelName })

--- a/index.test.js
+++ b/index.test.js
@@ -1,6 +1,7 @@
-import test, { describe, it, after } from "node:test"
+import test, { describe, it, after, beforeEach } from "node:test"
 import assert from "node:assert/strict"
 import { setTimeout as delay } from "node:timers/promises"
+import { PassThrough } from "node:stream"
 
 import {
   createProxyFetchHandler,
@@ -29,7 +30,18 @@ import {
   registerToolBridge,
   releaseToolBridge,
   buildToolsMap,
+  OpenAIProxyPlugin,
 } from "./index.js"
+
+import { dispatch, parseTools, runStdioServer } from "./mcp-tool-bridge.js"
+
+// Keep the suite hermetic: environment variables leaking in from the developer's
+// shell or CI (e.g. OPENCODE_LLM_PROXY_TOKEN) must not change test outcomes.
+// Tests that need these set do so explicitly inside the test body.
+beforeEach(() => {
+  delete process.env.OPENCODE_LLM_PROXY_TOKEN
+  delete process.env.OPENCODE_LLM_PROXY_CORS_ORIGIN
+})
 
 // ---------------------------------------------------------------------------
 // Integration: createProxyFetchHandler
@@ -2125,17 +2137,24 @@ function createToolCallClient({ toolName, toolArgs, callID = "call_1", finish = 
     event: {
       subscribe: async () => ({
         stream: (async function* () {
+          const tool = `${capturedSlotName}_${toolName}`
+          // Real OpenCode lifecycle: input is empty on "pending" and only populated on
+          // "running"; the tool-calling step ends with a step-finish for the same message.
           yield {
             type: "message.part.updated",
             properties: {
-              part: {
-                sessionID: "sess-tool-1",
-                type: "tool",
-                tool: `${capturedSlotName}_${toolName}`,
-                callID,
-                state: { status: "pending", input: toolArgs },
-              },
+              part: { sessionID: "sess-tool-1", messageID: "msg-1", type: "tool", tool, callID, state: { status: "pending", input: {} } },
             },
+          }
+          yield {
+            type: "message.part.updated",
+            properties: {
+              part: { sessionID: "sess-tool-1", messageID: "msg-1", type: "tool", tool, callID, state: { status: "running", input: toolArgs } },
+            },
+          }
+          yield {
+            type: "message.part.updated",
+            properties: { part: { sessionID: "sess-tool-1", messageID: "msg-1", type: "step-finish" } },
           }
         })(),
       }),
@@ -2584,4 +2603,598 @@ test("tool_choice: none disables tool calling even when tools are supplied", asy
   assert.equal(response.status, 200)
   // No mcp/tool bridge client methods were exercised because callerTools resolved to [].
   assert.equal(client.mcp, undefined)
+})
+
+test("POST /v1beta/models/:model:streamGenerateContent emits a functionCall in the final chunk", async () => {
+  const client = createToolCallClient({
+    toolName: "get_weather",
+    toolArgs: { city: "NYC" },
+    providers: [{ id: "google", models: { "gemini-2.0-flash": { id: "gemini-2.0-flash" } } }],
+  })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1beta/models/gemini-2.0-flash:streamGenerateContent", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts: [{ text: "What's the weather in NYC?" }] }],
+      tools: [{ functionDeclarations: [{ name: "get_weather", description: "Get weather" }] }],
+    }),
+  })
+
+  const response = await handler(request)
+  const text = await response.text()
+  const chunks = text
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line))
+  const functionCall = chunks.at(-1).candidates[0].content.parts[0].functionCall
+
+  assert.ok(functionCall)
+  assert.equal(functionCall.name, "get_weather")
+  assert.deepEqual(functionCall.args, { city: "NYC" })
+})
+
+// ---------------------------------------------------------------------------
+// Integration: parallel tool calling (a single assistant turn requesting multiple
+// tools at once). The completed assistant message is the authoritative source of the
+// full set - it carries every tool part before the first goes pending - so the mock
+// returns them all from session.messages() while the event stream only surfaces the
+// first (which is what triggers the abort in runAgentTurn).
+// ---------------------------------------------------------------------------
+
+function createParallelToolCallClient({ tools, finish = "tool_calls", providers } = {}) {
+  let capturedSlotName = null
+  const toolPart = (tool, status, input) => ({
+    sessionID: "sess-par-1",
+    messageID: "msg-par-1",
+    type: "tool",
+    tool: `${capturedSlotName}_${tool.name}`,
+    callID: tool.callID,
+    state: { status, input },
+  })
+
+  return {
+    app: { log: async () => {} },
+    tool: { ids: async () => ({ data: [] }) },
+    config: {
+      providers: async () => ({
+        data: {
+          providers: providers ?? [{ id: "openai", models: { "gpt-4o": { id: "gpt-4o", name: "GPT-4o" } } }],
+        },
+      }),
+    },
+    mcp: {
+      disconnect: async () => {
+        throw new Error("not connected")
+      },
+      add: async ({ body }) => {
+        capturedSlotName = body.name
+        return { data: {} }
+      },
+    },
+    session: {
+      create: async () => ({ data: { id: "sess-par-1" } }),
+      promptAsync: async () => {},
+      abort: async () => ({ data: true }),
+      messages: async () => ({
+        data: [
+          {
+            info: {
+              role: "assistant",
+              tokens: { input: 7, output: 3, reasoning: 0, cache: { read: 0, write: 0 } },
+              finish,
+            },
+            parts: [{ type: "step-start" }, { type: "text", text: "" }, { type: "step-finish" }],
+          },
+        ],
+      }),
+    },
+    event: {
+      subscribe: async () => ({
+        stream: (async function* () {
+          // Real OpenCode emits parallel tool calls sequentially within one assistant
+          // message: each goes pending (empty input) then running (populated), and the
+          // step ends with a single step-finish. All belong to the same messageID.
+          for (const tool of tools) {
+            yield { type: "message.part.updated", properties: { part: toolPart(tool, "pending", {}) } }
+            yield { type: "message.part.updated", properties: { part: toolPart(tool, "running", tool.args) } }
+          }
+          yield {
+            type: "message.part.updated",
+            properties: { part: { sessionID: "sess-par-1", messageID: "msg-par-1", type: "step-finish" } },
+          }
+        })(),
+      }),
+    },
+  }
+}
+
+const PARALLEL_TOOLS = [
+  { name: "get_weather", args: { city: "NYC" }, callID: "call_1" },
+  { name: "get_time", args: { tz: "EST" }, callID: "call_2" },
+]
+
+test("POST /v1/chat/completions returns multiple tool_calls for parallel tool use", async () => {
+  const client = createParallelToolCallClient({ tools: PARALLEL_TOOLS })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      messages: [{ role: "user", content: "weather and time?" }],
+      tools: [
+        { type: "function", function: { name: "get_weather" } },
+        { type: "function", function: { name: "get_time" } },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(body.choices[0].finish_reason, "tool_calls")
+  const calls = body.choices[0].message.tool_calls
+  assert.equal(calls.length, 2)
+  assert.deepEqual(
+    calls.map((c) => c.function.name),
+    ["get_weather", "get_time"],
+  )
+  assert.deepEqual(
+    calls.map((c) => c.id),
+    ["call_1", "call_2"],
+  )
+  assert.deepEqual(JSON.parse(calls[1].function.arguments), { tz: "EST" })
+})
+
+test("POST /v1/chat/completions stream emits parallel tool_calls with distinct indexes", async () => {
+  const client = createParallelToolCallClient({ tools: PARALLEL_TOOLS })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/chat/completions", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      stream: true,
+      messages: [{ role: "user", content: "weather and time?" }],
+      tools: [
+        { type: "function", function: { name: "get_weather" } },
+        { type: "function", function: { name: "get_time" } },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const text = await response.text()
+  const toolChunk = text
+    .split("\n\n")
+    .map((block) => block.replace(/^data: /, ""))
+    .filter((line) => line && line !== "[DONE]")
+    .map((line) => JSON.parse(line))
+    .find((chunk) => chunk.choices?.[0]?.delta?.tool_calls)
+
+  assert.ok(toolChunk, "expected a chunk carrying tool_calls")
+  const calls = toolChunk.choices[0].delta.tool_calls
+  assert.equal(calls.length, 2)
+  assert.deepEqual(
+    calls.map((c) => c.index),
+    [0, 1],
+  )
+  assert.deepEqual(
+    calls.map((c) => c.function.name),
+    ["get_weather", "get_time"],
+  )
+  assert.ok(text.includes('"finish_reason":"tool_calls"'))
+})
+
+test("POST /v1/responses returns multiple function_call output items for parallel tool use", async () => {
+  const client = createParallelToolCallClient({ tools: PARALLEL_TOOLS })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      input: "weather and time?",
+      tools: [
+        { type: "function", name: "get_weather" },
+        { type: "function", name: "get_time" },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(body.output.length, 2)
+  assert.deepEqual(
+    body.output.map((item) => item.type),
+    ["function_call", "function_call"],
+  )
+  assert.deepEqual(
+    body.output.map((item) => item.name),
+    ["get_weather", "get_time"],
+  )
+  assert.deepEqual(
+    body.output.map((item) => item.call_id),
+    ["call_1", "call_2"],
+  )
+  assert.equal(body.parallel_tool_calls, true)
+})
+
+test("POST /v1/responses stream emits parallel function_call items with distinct output_index", async () => {
+  const client = createParallelToolCallClient({ tools: PARALLEL_TOOLS })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/responses", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      stream: true,
+      input: "weather and time?",
+      tools: [
+        { type: "function", name: "get_weather" },
+        { type: "function", name: "get_time" },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const text = await response.text()
+  const doneEvents = parseSseStream(text).filter((e) => e.event === "response.output_item.done")
+
+  assert.equal(doneEvents.length, 2)
+  assert.deepEqual(
+    doneEvents.map((e) => e.data.output_index),
+    [1, 2],
+  )
+  assert.deepEqual(
+    doneEvents.map((e) => e.data.item.name),
+    ["get_weather", "get_time"],
+  )
+})
+
+test("POST /v1/messages returns multiple tool_use blocks for parallel tool use", async () => {
+  const client = createParallelToolCallClient({ tools: PARALLEL_TOOLS })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/messages", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      max_tokens: 100,
+      messages: [{ role: "user", content: "weather and time?" }],
+      tools: [
+        { name: "get_weather", input_schema: { type: "object" } },
+        { name: "get_time", input_schema: { type: "object" } },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  assert.equal(body.stop_reason, "tool_use")
+  assert.equal(body.content.length, 2)
+  assert.deepEqual(
+    body.content.map((block) => block.type),
+    ["tool_use", "tool_use"],
+  )
+  assert.deepEqual(
+    body.content.map((block) => block.name),
+    ["get_weather", "get_time"],
+  )
+  assert.deepEqual(body.content[1].input, { tz: "EST" })
+})
+
+test("POST /v1/messages stream emits parallel tool_use blocks with distinct indexes", async () => {
+  const client = createParallelToolCallClient({ tools: PARALLEL_TOOLS })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1/messages", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      model: "gpt-4o",
+      max_tokens: 100,
+      stream: true,
+      messages: [{ role: "user", content: "weather and time?" }],
+      tools: [
+        { name: "get_weather", input_schema: { type: "object" } },
+        { name: "get_time", input_schema: { type: "object" } },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const text = await response.text()
+  const starts = parseSseStream(text).filter(
+    (e) => e.event === "content_block_start" && e.data.content_block?.type === "tool_use",
+  )
+
+  assert.equal(starts.length, 2)
+  assert.deepEqual(
+    starts.map((e) => e.data.index),
+    [0, 1],
+  )
+  assert.deepEqual(
+    starts.map((e) => e.data.content_block.name),
+    ["get_weather", "get_time"],
+  )
+})
+
+test("POST /v1beta/models/:model:generateContent returns multiple functionCall parts for parallel tool use", async () => {
+  const client = createParallelToolCallClient({
+    tools: PARALLEL_TOOLS,
+    providers: [{ id: "google", models: { "gemini-2.0-flash": { id: "gemini-2.0-flash" } } }],
+  })
+  const handler = createProxyFetchHandler(client)
+  const request = new Request("http://127.0.0.1:4010/v1beta/models/gemini-2.0-flash:generateContent", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      contents: [{ role: "user", parts: [{ text: "weather and time?" }] }],
+      tools: [
+        {
+          functionDeclarations: [
+            { name: "get_weather", description: "Get weather" },
+            { name: "get_time", description: "Get time" },
+          ],
+        },
+      ],
+    }),
+  })
+
+  const response = await handler(request)
+  const body = await response.json()
+
+  assert.equal(response.status, 200)
+  const parts = body.candidates[0].content.parts
+  assert.equal(parts.length, 2)
+  assert.deepEqual(
+    parts.map((part) => part.functionCall.name),
+    ["get_weather", "get_time"],
+  )
+  assert.deepEqual(parts[1].functionCall.args, { tz: "EST" })
+})
+
+
+
+describe("mcp-tool-bridge parseTools", () => {
+  it("parses a valid JSON array", () => {
+    const tools = parseTools('[{"name":"a"},{"name":"b"}]')
+    assert.deepEqual(tools, [{ name: "a" }, { name: "b" }])
+  })
+
+  it("defaults to an empty array when input is undefined", () => {
+    assert.deepEqual(parseTools(undefined), [])
+  })
+
+  it("returns an empty array and reports the error on malformed JSON", () => {
+    let reported
+    const tools = parseTools("{not json", (err) => {
+      reported = err
+    })
+    assert.deepEqual(tools, [])
+    assert.ok(reported instanceof Error)
+  })
+
+  it("returns an empty array when JSON is valid but not an array", () => {
+    assert.deepEqual(parseTools('{"name":"a"}'), [])
+  })
+})
+
+describe("mcp-tool-bridge dispatch", () => {
+  it("responds to initialize with server info and the requested protocol version", () => {
+    const response = dispatch({ id: 1, method: "initialize", params: { protocolVersion: "2025-01-01" } })
+    assert.equal(response.jsonrpc, "2.0")
+    assert.equal(response.id, 1)
+    assert.equal(response.result.protocolVersion, "2025-01-01")
+    assert.deepEqual(response.result.capabilities, { tools: {} })
+    assert.equal(response.result.serverInfo.name, "opencode-llm-proxy-bridge")
+  })
+
+  it("falls back to the default protocol version when none is supplied", () => {
+    const response = dispatch({ id: 1, method: "initialize" })
+    assert.equal(response.result.protocolVersion, "2024-11-05")
+  })
+
+  it("maps tool schemas into MCP tools/list shape", () => {
+    const tools = [
+      { name: "get_weather", description: "Get weather", parameters: { type: "object", properties: { city: {} } } },
+      { name: "no_desc" },
+    ]
+    const response = dispatch({ id: 2, method: "tools/list" }, tools)
+    assert.deepEqual(response.result.tools, [
+      { name: "get_weather", description: "Get weather", inputSchema: { type: "object", properties: { city: {} } } },
+      { name: "no_desc", description: "", inputSchema: { type: "object", properties: {} } },
+    ])
+  })
+
+  it("returns an empty tools list when no tools are configured", () => {
+    const response = dispatch({ id: 3, method: "tools/list" })
+    assert.deepEqual(response.result.tools, [])
+  })
+
+  it("responds to ping with an empty result", () => {
+    const response = dispatch({ id: 4, method: "ping" })
+    assert.deepEqual(response.result, {})
+  })
+
+  it("returns a placeholder text content for tools/call", () => {
+    const response = dispatch({ id: 5, method: "tools/call", params: { name: "x" } })
+    assert.equal(response.result.content[0].type, "text")
+    assert.match(response.result.content[0].text, /intercepted by opencode-llm-proxy/)
+  })
+
+  it("returns null (no response) for notifications/initialized", () => {
+    assert.equal(dispatch({ method: "notifications/initialized" }), null)
+  })
+
+  it("returns null for a request without an id", () => {
+    assert.equal(dispatch({ method: "ping" }), null)
+  })
+
+  it("returns a JSON-RPC method-not-found error for unknown methods", () => {
+    const response = dispatch({ id: 6, method: "does/not/exist" })
+    assert.equal(response.error.code, -32601)
+    assert.match(response.error.message, /Method not found: does\/not\/exist/)
+  })
+
+  it("does not emit an error response for an unknown method without an id", () => {
+    assert.equal(dispatch({ method: "does/not/exist" }), null)
+  })
+})
+
+describe("mcp-tool-bridge runStdioServer", () => {
+  function collect(stream) {
+    const chunks = []
+    stream.on("data", (chunk) => chunks.push(chunk.toString()))
+    return () => chunks.join("")
+  }
+
+  it("processes newline-delimited requests and writes JSON-RPC responses", async () => {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const errorOutput = new PassThrough()
+    const readOutput = collect(output)
+    const readError = collect(errorOutput)
+    let ended = false
+
+    runStdioServer([{ name: "get_weather", description: "d", parameters: { type: "object" } }], {
+      input,
+      output,
+      errorOutput,
+      onEnd: () => {
+        ended = true
+      },
+    })
+
+    input.write('{"jsonrpc":"2.0","id":1,"method":"ping"}\n')
+    input.write('{"jsonrpc":"2.0","id":2,"method":"tools/list"}\n')
+    input.write("\n") // blank line is ignored
+    input.write("{ not valid json\n") // malformed line goes to errorOutput
+    input.write('{"jsonrpc":"2.0","method":"notifications/initialized"}\n') // notification -> no output
+    input.end()
+
+    await delay(10)
+
+    const lines = readOutput()
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line))
+
+    assert.equal(lines.length, 2)
+    assert.deepEqual(lines[0], { jsonrpc: "2.0", id: 1, result: {} })
+    assert.equal(lines[1].result.tools[0].name, "get_weather")
+    assert.match(readError(), /failed to parse message/)
+    assert.equal(ended, true)
+  })
+
+  it("reassembles a request split across multiple chunks", async () => {
+    const input = new PassThrough()
+    const output = new PassThrough()
+    const readOutput = collect(output)
+
+    runStdioServer([], {
+      input,
+      output,
+      errorOutput: new PassThrough(),
+      onEnd: () => {},
+    })
+
+    input.write('{"jsonrpc":"2.0","id":')
+    await delay(5)
+    input.write('7,"method":"ping"}\n')
+    await delay(5)
+
+    assert.deepEqual(JSON.parse(readOutput().trim()), { jsonrpc: "2.0", id: 7, result: {} })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// OpenAIProxyPlugin (plugin entrypoint / server bootstrap)
+// ---------------------------------------------------------------------------
+
+describe("OpenAIProxyPlugin", () => {
+  const STATE_KEY = "__opencodeOpenAIProxyState"
+
+  function withMockedBun(serve, run) {
+    const savedBun = globalThis.Bun
+    delete globalThis[STATE_KEY]
+    globalThis.Bun = { serve }
+    return Promise.resolve()
+      .then(run)
+      .finally(() => {
+        if (savedBun === undefined) delete globalThis.Bun
+        else globalThis.Bun = savedBun
+        delete globalThis[STATE_KEY]
+      })
+  }
+
+  it("starts a Bun server and records it in global state", async () => {
+    const calls = []
+    const fakeServer = { stopped: false }
+
+    await withMockedBun(
+      (opts) => {
+        calls.push(opts)
+        return fakeServer
+      },
+      async () => {
+        process.env.OPENCODE_LLM_PROXY_HOST = "127.0.0.1"
+        process.env.OPENCODE_LLM_PROXY_PORT = "4999"
+        try {
+          const result = await OpenAIProxyPlugin({ client: createClient() })
+
+          assert.deepEqual(result, {})
+          assert.equal(calls.length, 1)
+          assert.equal(calls[0].hostname, "127.0.0.1")
+          assert.equal(calls[0].port, 4999)
+          assert.equal(typeof calls[0].fetch, "function")
+          assert.equal(globalThis[STATE_KEY].started, true)
+          assert.equal(globalThis[STATE_KEY].server, fakeServer)
+        } finally {
+          delete process.env.OPENCODE_LLM_PROXY_HOST
+          delete process.env.OPENCODE_LLM_PROXY_PORT
+        }
+      },
+    )
+  })
+
+  it("does not start a second server when already started", async () => {
+    let served = false
+
+    await withMockedBun(
+      () => {
+        served = true
+        return {}
+      },
+      async () => {
+        globalThis[STATE_KEY] = { started: true }
+        const result = await OpenAIProxyPlugin({ client: createClient() })
+
+        assert.deepEqual(result, {})
+        assert.equal(served, false)
+      },
+    )
+  })
+
+  it("returns gracefully when Bun.serve throws (e.g. port in use)", async () => {
+    await withMockedBun(
+      () => {
+        throw new Error("EADDRINUSE: port already in use")
+      },
+      async () => {
+        const result = await OpenAIProxyPlugin({ client: createClient() })
+
+        assert.deepEqual(result, {})
+        assert.equal(globalThis[STATE_KEY].server, undefined)
+      },
+    )
+  })
 })

--- a/mcp-tool-bridge.js
+++ b/mcp-tool-bridge.js
@@ -11,64 +11,59 @@
 // Protocol: JSON-RPC 2.0 messages, newline-delimited, over stdin/stdout.
 // stdout MUST only ever contain JSON-RPC messages - all diagnostics go to stderr.
 
-const toolsJson = process.env.OPENCODE_LLM_PROXY_BRIDGE_TOOLS ?? "[]"
-
-let tools = []
-try {
-  const parsed = JSON.parse(toolsJson)
-  if (Array.isArray(parsed)) tools = parsed
-} catch (error) {
-  process.stderr.write(`opencode-llm-proxy bridge: failed to parse tool schemas: ${error}\n`)
+// Parses the JSON tool schemas supplied via env. Always returns an array; on any
+// parse error it returns [] and (optionally) reports the failure via onError.
+export function parseTools(toolsJson, onError) {
+  try {
+    const parsed = JSON.parse(toolsJson ?? "[]")
+    if (Array.isArray(parsed)) return parsed
+  } catch (error) {
+    onError?.(error)
+  }
+  return []
 }
 
-function send(message) {
-  process.stdout.write(JSON.stringify(message) + "\n")
+function result(id, value) {
+  if (id === undefined || id === null) return null
+  return { jsonrpc: "2.0", id, result: value }
 }
 
-function respondResult(id, result) {
-  if (id === undefined || id === null) return
-  send({ jsonrpc: "2.0", id, result })
+function error(id, code, message) {
+  if (id === undefined || id === null) return null
+  return { jsonrpc: "2.0", id, error: { code, message } }
 }
 
-function respondError(id, code, message) {
-  if (id === undefined || id === null) return
-  send({ jsonrpc: "2.0", id, error: { code, message } })
-}
-
-function handleMessage(message) {
-  const { id, method, params } = message
+// Pure JSON-RPC dispatcher. Given a parsed request message and the tool schemas,
+// returns the response object to send, or null when no response is expected
+// (notifications, or requests without an id).
+export function dispatch(message, tools = []) {
+  const { id, method, params } = message ?? {}
 
   switch (method) {
-    case "initialize": {
-      respondResult(id, {
+    case "initialize":
+      return result(id, {
         protocolVersion: params?.protocolVersion ?? "2024-11-05",
         capabilities: { tools: {} },
         serverInfo: { name: "opencode-llm-proxy-bridge", version: "1.0.0" },
       })
-      return
-    }
     case "notifications/initialized":
       // Notification, no response expected.
-      return
-    case "ping": {
-      respondResult(id, {})
-      return
-    }
-    case "tools/list": {
-      respondResult(id, {
+      return null
+    case "ping":
+      return result(id, {})
+    case "tools/list":
+      return result(id, {
         tools: tools.map((tool) => ({
           name: tool.name,
           description: tool.description ?? "",
           inputSchema: tool.parameters ?? { type: "object", properties: {} },
         })),
       })
-      return
-    }
-    case "tools/call": {
+    case "tools/call":
       // Never actually reached in practice: the proxy aborts the OpenCode session as
       // soon as it observes the tool-call part on the event stream, before this
       // response would be consumed. Returned only as a safety net.
-      respondResult(id, {
+      return result(id, {
         content: [
           {
             type: "text",
@@ -76,32 +71,52 @@ function handleMessage(message) {
           },
         ],
       })
-      return
-    }
-    default: {
-      respondError(id, -32601, `Method not found: ${method}`)
-    }
+    default:
+      return error(id, -32601, `Method not found: ${method}`)
   }
 }
 
-let buffer = ""
-process.stdin.setEncoding("utf8")
-process.stdin.on("data", (chunk) => {
-  buffer += chunk
-  let newlineIndex
-  while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
-    const line = buffer.slice(0, newlineIndex).trim()
-    buffer = buffer.slice(newlineIndex + 1)
-    if (!line) continue
-    try {
-      const message = JSON.parse(line)
-      handleMessage(message)
-    } catch (error) {
-      process.stderr.write(`opencode-llm-proxy bridge: failed to parse message: ${error}\n`)
-    }
-  }
-})
+// Wires the pure dispatcher up to newline-delimited JSON-RPC streams. Streams are
+// injectable (defaulting to the process stdio) so the parsing loop can be unit
+// tested without spawning a child process. Only invoked when this module is run as
+// a script (see the guard below), so importing it for tests has no side effects.
+export function runStdioServer(tools, options = {}) {
+  const input = options.input ?? process.stdin
+  const output = options.output ?? process.stdout
+  const errorOutput = options.errorOutput ?? process.stderr
+  const onEnd = options.onEnd ?? (() => process.exit(0))
 
-process.stdin.on("end", () => {
-  process.exit(0)
-})
+  function send(message) {
+    output.write(JSON.stringify(message) + "\n")
+  }
+
+  let buffer = ""
+  input.setEncoding("utf8")
+  input.on("data", (chunk) => {
+    buffer += chunk
+    let newlineIndex
+    while ((newlineIndex = buffer.indexOf("\n")) !== -1) {
+      const line = buffer.slice(0, newlineIndex).trim()
+      buffer = buffer.slice(newlineIndex + 1)
+      if (!line) continue
+      try {
+        const message = JSON.parse(line)
+        const response = dispatch(message, tools)
+        if (response) send(response)
+      } catch (err) {
+        errorOutput.write(`opencode-llm-proxy bridge: failed to parse message: ${err}\n`)
+      }
+    }
+  })
+
+  input.on("end", onEnd)
+}
+
+// Only start the stdio server when executed directly (`node mcp-tool-bridge.js`),
+// not when imported by tests.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const tools = parseTools(process.env.OPENCODE_LLM_PROXY_BRIDGE_TOOLS, (err) =>
+    process.stderr.write(`opencode-llm-proxy bridge: failed to parse tool schemas: ${err}\n`),
+  )
+  runStdioServer(tools)
+}


### PR DESCRIPTION
## What & why

The proxy now returns **every** tool the model calls in a single turn — not just the first — across **all four API formats**, streaming and non-streaming:

- OpenAI Chat Completions → `tool_calls[]` (with per-call `index` when streaming)
- OpenAI Responses → multiple `function_call` items (distinct `output_index`)
- Anthropic Messages → multiple `tool_use` blocks (distinct block index)
- Gemini → multiple `functionCall` parts

## The fix (found via a live smoke test)

Tool-call capture was reworked after observing OpenCode's real event lifecycle against a live server:

- **Source calls from the live event stream** — `session.messages()` does not carry the tool parts in current OpenCode.
- **Read arguments from `running`/`completed`**, not the empty `pending` snapshot (which is `{}`), so args are always populated.
- **Scope to the tool-calling message** and **abort at its `step-finish`** — capturing all parallel calls while preventing a follow-up step from running on the bridge's placeholder results.

Verified end-to-end against a running OpenCode instance with a real model: single + parallel calls return correct names, arguments, and IDs on every endpoint (streaming and non-streaming). The same run also confirmed streaming now emits content (a regression that affected the previously published build).

## Hardening

- Test suite made **hermetic** (isolates `OPENCODE_LLM_PROXY_*` env vars).
- `mcp-tool-bridge.js` made importable/testable; its JSON-RPC handler is now covered.
- Added `OpenAIProxyPlugin` bootstrap tests.
- **170 tests, 95%+ line coverage**, lint clean.

## Docs

- README updated: parallel tool calls documented, under-the-hood mechanism corrected, outdated "one call per turn" limitation removed.

## Release

Conventional `feat:` — release-please will cut **v1.8.0** and publish to npm on merge of its release PR.