### PR TITLE
docs: integration recipes, security, comparisons, and examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules/
+promotion.md
+docs/promotion-drafts/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 opencode-llm-proxy is an [OpenCode](https://opencode.ai) plugin that starts a local HTTP server on `http://127.0.0.1:4010`. It translates between the API format your tool speaks and whichever LLM provider OpenCode has configured — so you never reconfigure the same models twice.
 
+![opencode-llm-proxy demo](docs/assets/demo.gif)
+
 ```
 Your tool (OpenAI / Anthropic / Gemini SDK, coding agent, etc.)
          │
@@ -32,6 +34,39 @@ Your tool (OpenAI / Anthropic / Gemini SDK, coding agent, etc.)
 
 ---
 
+## Works with
+
+| Tool / Client | API mode | Streaming | Tool calling | Notes |
+|---|---|---:|---:|---|
+| n8n AI Agent | OpenAI / Anthropic | yes | yes | Use native Chat Model credentials pointed at the proxy. See [recipe](docs/recipes/n8n.md) |
+| Open WebUI | OpenAI-compatible | yes | partial | Depends on Open WebUI feature support. See [recipe](docs/recipes/open-webui.md) |
+| LangChain | OpenAI / Anthropic | yes | yes | Works with normal SDK wrappers. See [recipe](docs/recipes/langchain.md) |
+| OpenAI SDK | Chat Completions / Responses | yes | yes | Use `baseURL` / `base_url` |
+| Anthropic SDK | Messages API | yes | yes | Use proxy base URL |
+| Gemini clients | Gemini-compatible | yes | yes | Use `/v1beta/models/...` endpoints |
+| Continue | OpenAI-compatible | yes | not primary | Good for editor model access. See [recipe](docs/recipes/continue.md) |
+| Zed | OpenAI-compatible | yes | not primary | Good for editor model access. See [recipe](docs/recipes/zed.md) |
+| Custom coding agents | OpenAI / Anthropic / Gemini | yes | yes | Best fit for client-executed tools. See [recipe](docs/recipes/custom-agent.md) |
+
+### SDKs & clients
+
+| Client | Endpoint type | Streaming | Tool calling | Notes |
+|---|---|---:|---:|---|
+| OpenAI SDK (JS/TS) | Chat Completions / Responses | yes | yes | Set `baseURL: ".../v1"` |
+| OpenAI SDK (Python) | Chat Completions / Responses | yes | yes | Set `base_url=".../v1"` |
+| Anthropic SDK (JS/TS) | Messages | yes | yes | Set `baseURL` to the proxy root (no `/v1`) |
+| Anthropic SDK (Python) | Messages | yes | yes | Set `base_url` to the proxy root (no `/v1`) |
+| Google Generative AI (JS) | Gemini `/v1beta` | yes | yes | Set `baseUrl` to the proxy root |
+| LangChain | OpenAI / Anthropic wrappers | yes | yes | `.bind_tools()` supported. See [recipe](docs/recipes/langchain.md) |
+| n8n | OpenAI / Anthropic | yes | yes | Native Chat Model + AI Agent nodes. See [recipe](docs/recipes/n8n.md) |
+| Open WebUI | OpenAI-compatible | yes | partial | Depends on Open WebUI feature support. See [recipe](docs/recipes/open-webui.md) |
+| Continue | OpenAI-compatible | yes | not primary | Editor chat/edit. See [recipe](docs/recipes/continue.md) |
+| Zed | OpenAI-compatible | yes | not primary | Editor chat/edit. See [recipe](docs/recipes/zed.md) |
+
+See also: [Security](docs/security.md) · [Comparisons](docs/comparisons.md) · [All recipes](docs/recipes/)
+
+---
+
 ## Contents
 
 - [Why](#why)
@@ -41,6 +76,9 @@ Your tool (OpenAI / Anthropic / Gemini SDK, coding agent, etc.)
 - [Tool calling](#tool-calling)
 - [Using with SDKs and tools](#using-with-sdks-and-tools)
   - [n8n](#n8n)
+- [Recipes](docs/recipes/)
+- [Security](docs/security.md)
+- [Comparisons](docs/comparisons.md)
 - [Finding model IDs](#finding-model-ids)
 - [API reference](#api-reference)
 - [How it works](#how-it-works)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 opencode-llm-proxy is an [OpenCode](https://opencode.ai) plugin that starts a local HTTP server on `http://127.0.0.1:4010`. It translates between the API format your tool speaks and whichever LLM provider OpenCode has configured — so you never reconfigure the same models twice.
 
-![opencode-llm-proxy demo](docs/assets/demo.gif)
-
 ```
 Your tool (OpenAI / Anthropic / Gemini SDK, coding agent, etc.)
          │

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -7,7 +7,7 @@ filenames below so existing references resolve.
 
 | File | Used by | Notes |
 |---|---|---|
-| `demo.gif` | README hero | 20–40s demo, referenced directly under the intro paragraph |
+| `demo.gif` | README hero | 20–40s demo. Once added, re-insert `![opencode-llm-proxy demo](docs/assets/demo.gif)` under the intro paragraph in the README |
 | `models-endpoint.png` | docs | `curl /v1/models` output |
 | `n8n-credential.png` | docs | n8n OpenAI credential configured with proxy base URL |
 | `open-webui-settings.png` | docs | Open WebUI connection settings |
@@ -33,5 +33,6 @@ filenames below so existing references resolve.
 - GitHub release page
 
 > These are placeholders documented in the promotion plan. Replace this note
-> with the actual media before publishing widely. Until `demo.gif` exists the
-> README image reference will show as broken.
+> with the actual media before publishing widely. The README image reference was
+> removed until `demo.gif` exists — re-add it (see the table above) once the GIF
+> is recorded.

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,37 @@
+# docs/assets
+
+Media assets for the README and docs. Drop the final files here with the
+filenames below so existing references resolve.
+
+## Expected files
+
+| File | Used by | Notes |
+|---|---|---|
+| `demo.gif` | README hero | 20–40s demo, referenced directly under the intro paragraph |
+| `models-endpoint.png` | docs | `curl /v1/models` output |
+| `n8n-credential.png` | docs | n8n OpenAI credential configured with proxy base URL |
+| `open-webui-settings.png` | docs | Open WebUI connection settings |
+| `tool-calling-response.png` | docs | Tool-calling request and response |
+
+## Demo GIF storyboard (20–40s)
+
+1. Open a terminal with `opencode` running.
+2. Show proxy startup on `http://127.0.0.1:4010`.
+3. Run `curl http://127.0.0.1:4010/v1/models`.
+4. Show models from OpenCode providers.
+5. Send a chat completion request.
+6. Send a small tool/function calling request.
+7. Show the returned tool call.
+8. End card: "Use one OpenCode model setup from n8n, Open WebUI, LangChain,
+   Continue, Zed, and coding agents."
+
+## Additional screenshots to capture
+
+- README top section with badges and architecture diagram
+- n8n AI Agent node using the model
+- npm package page
+- GitHub release page
+
+> These are placeholders documented in the promotion plan. Replace this note
+> with the actual media before publishing widely. Until `demo.gif` exists the
+> README image reference will show as broken.

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -1,0 +1,35 @@
+# Comparisons
+
+opencode-llm-proxy is deliberately narrow: it reuses the providers you already configured in OpenCode and exposes them through common client API formats. Here's how it relates to adjacent tools.
+
+## vs LiteLLM
+
+LiteLLM is a general-purpose provider router/proxy. opencode-llm-proxy is focused on reusing the providers already configured in OpenCode and making them available through common client API formats.
+
+- Use **LiteLLM** if you want a standalone production gateway with its own provider configuration, routing, budgets, and key management.
+- Use **opencode-llm-proxy** if your model configuration already lives in OpenCode and you want local tools to reuse it without re-entering keys.
+
+## vs OpenRouter
+
+OpenRouter is a hosted router and provider marketplace with its own billing and API keys. opencode-llm-proxy is local and backed by your OpenCode setup.
+
+- Use **OpenRouter** for a hosted, internet-facing endpoint and access to a broad model catalog through one account.
+- Use **opencode-llm-proxy** to keep everything local and driven by the providers OpenCode already has authenticated.
+
+## vs direct provider API keys
+
+Configuring a provider's API key directly in each tool is simplest when you only have one tool.
+
+- Use **direct keys** for a single tool with a single provider.
+- Use **opencode-llm-proxy** when multiple tools should share the same OpenCode model setup, so you configure providers once and swap models in one place.
+
+## vs Ollama's OpenAI-compatible endpoint
+
+Ollama exposes an OpenAI-compatible API for its local models only.
+
+- Use **Ollama's endpoint** if you only ever use local Ollama models.
+- Use **opencode-llm-proxy** to expose Ollama *and* every other provider OpenCode manages (GitHub Copilot, Anthropic, Bedrock, OpenRouter, ...) behind one endpoint and multiple API formats.
+
+## Summary
+
+opencode-llm-proxy is not trying to be a production gateway or a hosted marketplace. Its value is that your model setup already lives in OpenCode, and this makes that setup usable from OpenAI-, Anthropic-, Gemini-, and Responses-API-compatible tools locally, with streaming and real tool/function calling.

--- a/docs/examples/n8n/README.md
+++ b/docs/examples/n8n/README.md
@@ -1,0 +1,44 @@
+# n8n example workflow
+
+`opencode-llm-proxy-demo.workflow.json` is an importable n8n workflow that
+demonstrates using OpenCode models through the proxy in three ways:
+
+- an **OpenAI Chat Model** node pointed at `opencode-llm-proxy`
+- a **Basic LLM Chain** for simple prompt/response
+- an **AI Agent** node with a **Calculator** tool, showing real tool/function calling
+
+## Import
+
+n8n → top-right menu → **Import from File** → select
+`opencode-llm-proxy-demo.workflow.json`.
+
+## Setup before running
+
+1. Start OpenCode with the proxy exposed to n8n and a token set:
+
+   ```bash
+   OPENCODE_LLM_PROXY_HOST=0.0.0.0 \
+   OPENCODE_LLM_PROXY_TOKEN=some-long-random-token \
+   opencode
+   ```
+
+2. In n8n, create an **OpenAI** credential named `OpenCode Proxy`:
+   - **Base URL**: `http://<opencode-host-ip>:4010/v1`
+   - **API Key**: your token
+
+3. Open the **OpenCode Chat Model** node, re-select the credential if needed,
+   and pick a model from the dropdown (it auto-populates from `GET /v1/models`).
+
+4. Run the workflow with **Test workflow**.
+
+> The `credentials.id` in the JSON is a placeholder
+> (`REPLACE_WITH_YOUR_CREDENTIAL_ID`). n8n will prompt you to select your own
+> credential on first open — just pick `OpenCode Proxy`.
+
+## Notes
+
+- Node `typeVersion`s target a recent n8n release; n8n's importer will migrate
+  them if your version differs.
+- Tool calling requires the npm plugin install (so `mcp-tool-bridge.js` is
+  present) and `node` on `PATH` where OpenCode runs.
+- See the full [n8n recipe](../../recipes/n8n.md) and [security notes](../../security.md).

--- a/docs/examples/n8n/opencode-llm-proxy-demo.workflow.json
+++ b/docs/examples/n8n/opencode-llm-proxy-demo.workflow.json
@@ -1,0 +1,111 @@
+{
+  "name": "opencode-llm-proxy demo",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "5f1a2b3c-0001-4a00-8000-000000000001",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [-40, 300]
+    },
+    {
+      "parameters": {
+        "model": {
+          "__rl": true,
+          "mode": "list",
+          "value": "github-copilot/claude-sonnet-4.6",
+          "cachedResultName": "github-copilot/claude-sonnet-4.6"
+        },
+        "options": {}
+      },
+      "id": "5f1a2b3c-0002-4a00-8000-000000000002",
+      "name": "OpenCode Chat Model",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+      "typeVersion": 1.2,
+      "position": [220, 520],
+      "credentials": {
+        "openAiApi": {
+          "id": "REPLACE_WITH_YOUR_CREDENTIAL_ID",
+          "name": "OpenCode Proxy"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "Explain what an n8n workflow is in two sentences.",
+        "messages": {}
+      },
+      "id": "5f1a2b3c-0003-4a00-8000-000000000003",
+      "name": "Basic LLM Chain",
+      "type": "@n8n/n8n-nodes-langchain.chainLlm",
+      "typeVersion": 1.5,
+      "position": [300, 180]
+    },
+    {
+      "parameters": {
+        "promptType": "define",
+        "text": "What is 47 * 89? Use the calculator tool to be sure, then state the result.",
+        "options": {}
+      },
+      "id": "5f1a2b3c-0004-4a00-8000-000000000004",
+      "name": "AI Agent",
+      "type": "@n8n/n8n-nodes-langchain.agent",
+      "typeVersion": 1.7,
+      "position": [640, 300]
+    },
+    {
+      "parameters": {},
+      "id": "5f1a2b3c-0005-4a00-8000-000000000005",
+      "name": "Calculator",
+      "type": "@n8n/n8n-nodes-langchain.toolCalculator",
+      "typeVersion": 1,
+      "position": [640, 540]
+    },
+    {
+      "parameters": {
+        "content": "## opencode-llm-proxy demo\n\nBefore running:\n\n1. Start OpenCode with the proxy bound for network access:\n   `OPENCODE_LLM_PROXY_HOST=0.0.0.0 OPENCODE_LLM_PROXY_TOKEN=your-token opencode`\n2. Create an **OpenAI** credential named \"OpenCode Proxy\":\n   - Base URL: `http://<opencode-host-ip>:4010/v1`\n   - API Key: your token\n3. Open the **OpenCode Chat Model** node and pick a model from the dropdown\n   (it auto-populates from `GET /v1/models`).\n\nThe **Basic LLM Chain** shows simple prompt/response.\nThe **AI Agent** + **Calculator** shows real tool/function calling.",
+        "height": 300,
+        "width": 420
+      },
+      "id": "5f1a2b3c-0006-4a00-8000-000000000006",
+      "name": "Read me",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [-560, 160]
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          { "node": "Basic LLM Chain", "type": "main", "index": 0 },
+          { "node": "AI Agent", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "OpenCode Chat Model": {
+      "ai_languageModel": [
+        [
+          { "node": "Basic LLM Chain", "type": "ai_languageModel", "index": 0 },
+          { "node": "AI Agent", "type": "ai_languageModel", "index": 0 }
+        ]
+      ]
+    },
+    "Calculator": {
+      "ai_tool": [
+        [
+          { "node": "AI Agent", "type": "ai_tool", "index": 0 }
+        ]
+      ]
+    }
+  },
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "pinData": {},
+  "meta": {
+    "templateCredsSetupCompleted": false
+  }
+}

--- a/docs/examples/open-webui-docker/.env.example
+++ b/docs/examples/open-webui-docker/.env.example
@@ -1,0 +1,7 @@
+# Bearer token — must match the OPENCODE_LLM_PROXY_TOKEN you start OpenCode with.
+OPENCODE_LLM_PROXY_TOKEN=change-me-to-a-long-random-token
+
+# How the Open WebUI container reaches the proxy.
+# - Docker Desktop (macOS/Windows) or Linux with host-gateway: host.docker.internal
+# - OpenCode on another LAN machine: that machine's IP, e.g. 192.168.1.50
+PROXY_HOST=host.docker.internal

--- a/docs/examples/open-webui-docker/README.md
+++ b/docs/examples/open-webui-docker/README.md
@@ -1,0 +1,83 @@
+# Open WebUI + opencode-llm-proxy (Docker Compose)
+
+Run [Open WebUI](https://github.com/open-webui/open-webui) in Docker and point it
+at an `opencode-llm-proxy` instance so every model OpenCode has configured shows
+up in Open WebUI's model picker — no per-model API keys inside Open WebUI.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed, running on the **host**
+- Docker + Docker Compose
+
+## 1. Start OpenCode with the proxy exposed
+
+Open WebUI runs in a container, so it cannot reach `127.0.0.1` on the host.
+Bind the proxy to all interfaces and set a bearer token:
+
+```bash
+OPENCODE_LLM_PROXY_HOST=0.0.0.0 \
+OPENCODE_LLM_PROXY_TOKEN=change-me-to-a-long-random-token \
+opencode
+```
+
+## 2. Configure the connection
+
+Copy `.env.example` to `.env` and set the same token:
+
+```bash
+cp .env.example .env
+# edit .env and set OPENCODE_LLM_PROXY_TOKEN
+```
+
+The compose file wires these into Open WebUI's OpenAI connection:
+
+- `OPENAI_API_BASE_URL` → the proxy's `/v1` endpoint
+- `OPENAI_API_KEY` → your bearer token
+
+### Reaching the proxy from the container
+
+| Where OpenCode runs | Use for `PROXY_HOST` |
+|---|---|
+| Same machine as Docker (Docker Desktop, macOS/Windows) | `host.docker.internal` |
+| Same machine, Linux Docker Engine | your host's Docker bridge IP (often `172.17.0.1`) or use `extra_hosts` below |
+| A different machine on your LAN | that machine's LAN IP, e.g. `192.168.1.50` |
+
+The compose file below already adds `host.docker.internal` via `extra_hosts`, so
+it works on Linux too when `PROXY_HOST=host.docker.internal`.
+
+## 3. Start Open WebUI
+
+```bash
+docker compose up -d
+```
+
+Open http://localhost:3000, create the first account, and your OpenCode models
+appear in the model picker.
+
+## 4. Test it
+
+From inside the container, confirm the proxy is reachable:
+
+```bash
+docker compose exec open-webui \
+  curl -s http://${PROXY_HOST:-host.docker.internal}:4010/v1/models \
+  -H "Authorization: Bearer $OPENCODE_LLM_PROXY_TOKEN" | head
+```
+
+## Troubleshooting
+
+- **No models in picker**: the container can't reach the proxy. Re-run the test
+  curl above; fix `PROXY_HOST` per the table.
+- **`Connection refused`**: the proxy is bound to `127.0.0.1`. Restart OpenCode
+  with `OPENCODE_LLM_PROXY_HOST=0.0.0.0`.
+- **`401 Unauthorized`**: `.env` token doesn't match `OPENCODE_LLM_PROXY_TOKEN`.
+- **macOS firewall**: allow the `opencode` binary (System Settings → Network →
+  Firewall), or connections are silently dropped.
+- **Linux, `host.docker.internal` unresolved**: keep the `extra_hosts` mapping in
+  the compose file, or set `PROXY_HOST` to the host's LAN IP.
+
+## Security notes
+
+- Always set `OPENCODE_LLM_PROXY_TOKEN` when the proxy is bound beyond localhost.
+- Keep the proxy on your LAN; do not expose port `4010` to the internet.
+- See [../security.md](../security.md).

--- a/docs/examples/open-webui-docker/docker-compose.yml
+++ b/docs/examples/open-webui-docker/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:main
+    container_name: open-webui
+    ports:
+      - "3000:8080"
+    environment:
+      # Point Open WebUI's OpenAI connection at opencode-llm-proxy.
+      # PROXY_HOST defaults to host.docker.internal (Docker Desktop / macOS / Windows).
+      # On a different machine, set PROXY_HOST to that machine's LAN IP in .env.
+      - OPENAI_API_BASE_URL=http://${PROXY_HOST:-host.docker.internal}:4010/v1
+      - OPENAI_API_KEY=${OPENCODE_LLM_PROXY_TOKEN}
+    extra_hosts:
+      # Lets host.docker.internal resolve on Linux Docker Engine too.
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - open-webui:/app/backend/data
+    restart: unless-stopped
+
+volumes:
+  open-webui:

--- a/docs/recipes/cline.md
+++ b/docs/recipes/cline.md
@@ -1,0 +1,51 @@
+# Using opencode-llm-proxy with Cline
+
+## What this gives you
+
+Point [Cline](https://github.com/cline/cline) (the VS Code coding agent) at the proxy so it drives whatever model OpenCode has configured, with real client-executed tool calling for reading files, running commands, and editing code.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed (npm install, so `mcp-tool-bridge.js` is present)
+- `node` on `PATH` where OpenCode runs (required for tool calling)
+- Cline installed in VS Code
+
+## Step 1: Start OpenCode with the proxy
+
+```bash
+opencode
+```
+
+The proxy listens on `http://127.0.0.1:4010`.
+
+## Step 2: Configure Cline
+
+In Cline's settings, choose an **OpenAI Compatible** provider:
+
+- **Base URL**: `http://127.0.0.1:4010/v1`
+- **API Key**: `unused` (or your `OPENCODE_LLM_PROXY_TOKEN`)
+- **Model ID**: an OpenCode model ID, e.g. `github-copilot/claude-sonnet-4.6`
+
+Pick a model that is strong at tool/function calling for best agent behavior.
+
+## Step 3: Test it
+
+Give Cline a small task ("list the files in this folder and summarize the README"). It should issue tool calls that the proxy translates through to the underlying model and hand back as `tool_calls`.
+
+Verify available model IDs:
+
+```bash
+curl http://127.0.0.1:4010/v1/models | jq '.data[].id'
+```
+
+## Troubleshooting
+
+- **Tool calls never happen**: ensure you installed the npm plugin (not a copied `index.js`) and that `node` is on `PATH` where OpenCode runs.
+- **Concurrency limits**: heavy parallel agent use may exceed the tool-bridge pool. Raise `OPENCODE_LLM_PROXY_TOOL_BRIDGE_POOL_SIZE` (default `8`).
+- **Model not found**: use an exact ID from `/v1/models`.
+
+## Security notes
+
+- Agent tool calling executes actions — review Cline's auto-approve settings carefully.
+- Keep the proxy on localhost unless you must expose it; then set a token and firewall rules.
+- See [security.md](../security.md) for full guidance.

--- a/docs/recipes/continue.md
+++ b/docs/recipes/continue.md
@@ -1,0 +1,58 @@
+# Using opencode-llm-proxy with Continue
+
+## What this gives you
+
+Use any model OpenCode has configured inside the [Continue](https://continue.dev) VS Code or JetBrains extension through its OpenAI-compatible provider. Good for chat and edit; tool calling is not Continue's primary path.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed
+- Continue installed in VS Code or a JetBrains IDE
+
+## Step 1: Start OpenCode with the proxy
+
+```bash
+opencode
+```
+
+The proxy listens on `http://127.0.0.1:4010`.
+
+## Step 2: Configure Continue
+
+Edit `~/.continue/config.json`:
+
+```json
+{
+  "models": [
+    {
+      "title": "Claude via OpenCode",
+      "provider": "openai",
+      "model": "anthropic/claude-3-5-sonnet",
+      "apiBase": "http://127.0.0.1:4010/v1",
+      "apiKey": "unused"
+    }
+  ]
+}
+```
+
+Add more entries for additional models — each `model` value is an OpenCode model ID.
+
+## Step 3: Test it
+
+Reload the window, open the Continue panel, select "Claude via OpenCode", and send a prompt. Verify the backend separately if needed:
+
+```bash
+curl http://127.0.0.1:4010/v1/models | jq '.data[].id'
+```
+
+## Troubleshooting
+
+- **Model missing from picker**: confirm the entry saved in `config.json` and that `model` is a valid OpenCode ID.
+- **Requests fail**: check `curl http://127.0.0.1:4010/health` and that OpenCode is running.
+- **401**: set `apiKey` to your `OPENCODE_LLM_PROXY_TOKEN` if one is configured.
+
+## Security notes
+
+- Localhost binding is fine for editor use.
+- Only expose the proxy on a LAN with a token if you specifically need remote access.
+- See [security.md](../security.md) for full guidance.

--- a/docs/recipes/custom-agent.md
+++ b/docs/recipes/custom-agent.md
@@ -1,0 +1,72 @@
+# Using opencode-llm-proxy with a custom coding agent
+
+## What this gives you
+
+Build your own agent loop against a stable OpenAI / Anthropic / Gemini-compatible endpoint while OpenCode manages which model actually runs. You keep full control of tool execution on the client side — the proxy returns real tool calls for you to run and feed back.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed (npm install, so `mcp-tool-bridge.js` is present)
+- `node` on `PATH` where OpenCode runs (required for tool calling)
+- Any HTTP client or SDK (OpenAI, Anthropic, or Gemini)
+
+## Step 1: Start OpenCode with the proxy
+
+```bash
+opencode
+```
+
+The proxy listens on `http://127.0.0.1:4010`.
+
+## Step 2: Wire up your agent
+
+Use the OpenAI SDK (or raw HTTP) and declare your tools:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:4010/v1", api_key="unused")
+
+tools = [{
+    "type": "function",
+    "function": {
+        "name": "read_file",
+        "description": "Read a file from disk",
+        "parameters": {
+            "type": "object",
+            "properties": {"path": {"type": "string"}},
+            "required": ["path"],
+        },
+    },
+}]
+
+messages = [{"role": "user", "content": "Read README.md and summarize it."}]
+
+resp = client.chat.completions.create(
+    model="github-copilot/claude-sonnet-4.6",
+    messages=messages,
+    tools=tools,
+)
+```
+
+## Step 3: Run the agent loop
+
+1. Inspect `resp.choices[0].message.tool_calls`. The proxy returns one or several calls in a single turn (parallel tool calls are supported).
+2. Execute each tool locally.
+3. Append the assistant message and one `role: "tool"` message per call (with the matching `tool_call_id`) to `messages`.
+4. Send the full history back to the proxy and repeat until `finish_reason` is `stop`.
+
+The proxy is stateless between calls, so always send the complete conversation history.
+
+## Troubleshooting
+
+- **No tool calls returned**: install the npm plugin (includes `mcp-tool-bridge.js`) and ensure `node` is on `PATH`.
+- **Parallel calls exceed capacity**: raise `OPENCODE_LLM_PROXY_TOOL_BRIDGE_POOL_SIZE` (default `8`).
+- **Forcing a tool**: set `tool_choice` to a specific named tool; `tool_choice: "none"` disables tool use for a request.
+
+## Security notes
+
+- Your agent executes tools — validate arguments and sandbox side effects.
+- Keep the proxy on localhost for single-machine agents; use a token and firewall for LAN exposure.
+- Never log bearer tokens.
+- See [security.md](../security.md) for full guidance.

--- a/docs/recipes/langchain.md
+++ b/docs/recipes/langchain.md
@@ -1,0 +1,65 @@
+# Using opencode-llm-proxy with LangChain
+
+## What this gives you
+
+Drive LangChain chains and agents with any model OpenCode has configured, using the standard OpenAI or Anthropic wrappers. Streaming and tool/function calling both work.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed
+- Python with `langchain-openai` (or `langchain-anthropic`) installed
+
+## Step 1: Start OpenCode with the proxy
+
+```bash
+opencode
+```
+
+The proxy listens on `http://127.0.0.1:4010`.
+
+## Step 2: Configure LangChain
+
+Using the OpenAI-compatible wrapper:
+
+```python
+from langchain_openai import ChatOpenAI
+
+llm = ChatOpenAI(
+    model="anthropic/claude-3-5-sonnet",
+    openai_api_base="http://127.0.0.1:4010/v1",
+    openai_api_key="unused",
+)
+```
+
+Or the Anthropic wrapper:
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+llm = ChatAnthropic(
+    model="anthropic/claude-3-5-sonnet",
+    base_url="http://127.0.0.1:4010",
+    api_key="unused",
+)
+```
+
+## Step 3: Test it
+
+```python
+response = llm.invoke("What are the SOLID principles?")
+print(response.content)
+```
+
+Tool calling works with `.bind_tools([...])` and standard LangChain tool/agent constructs — the proxy translates the calls through to the underlying model.
+
+## Troubleshooting
+
+- **Connection refused**: OpenCode isn't running or the proxy port differs. Check `curl http://127.0.0.1:4010/health`.
+- **Model not found**: run `curl http://127.0.0.1:4010/v1/models` and use an exact ID.
+- **Tool calls not returned**: install the npm plugin (includes `mcp-tool-bridge.js`) and ensure `node` is on `PATH` where OpenCode runs.
+
+## Security notes
+
+- Keep `base_url` on localhost unless you deliberately expose the proxy.
+- If exposing on a LAN, set `OPENCODE_LLM_PROXY_TOKEN` and pass it as the API key.
+- See [security.md](../security.md) for full guidance.

--- a/docs/recipes/n8n.md
+++ b/docs/recipes/n8n.md
@@ -1,0 +1,63 @@
+# Using opencode-llm-proxy with n8n
+
+## What this gives you
+
+Use [n8n](https://n8n.io)'s native AI nodes (OpenAI Chat Model, Anthropic Chat Model, AI Agent) with whatever models OpenCode already has authenticated access to — GitHub Copilot, Anthropic, Bedrock, OpenRouter, local Ollama models, etc. — without configuring separate API keys inside n8n. Streaming and real tool/function calling work, so AI Agent nodes with attached Tools function correctly.
+
+## Prerequisites
+
+- OpenCode installed with at least one provider configured
+- `opencode-llm-proxy` installed as an OpenCode plugin
+- An n8n instance (self-hosted, Docker, or n8n Cloud with network access to the proxy host)
+- `node` on `PATH` on the OpenCode host (required for tool calling)
+
+## Step 1: Start OpenCode with the proxy
+
+Because n8n usually reaches the proxy over the network, bind to all interfaces and set a bearer token:
+
+```bash
+OPENCODE_LLM_PROXY_HOST=0.0.0.0 \
+OPENCODE_LLM_PROXY_TOKEN=some-long-random-token \
+opencode
+```
+
+The proxy now listens on port `4010` on every interface of that machine.
+
+## Step 2: Configure n8n
+
+Create a credential:
+
+- **OpenAI**: Base URL `http://<opencode-host-ip>:4010/v1`, API Key = your token
+- **Anthropic**: Base URL `http://<opencode-host-ip>:4010` (no `/v1` — the node appends `/v1/messages` itself), API Key = your token
+
+Then add an **OpenAI Chat Model** (or **Anthropic Chat Model**) node using that credential. The model dropdown calls `GET /v1/models` on the proxy and auto-populates with every model OpenCode has connected — pick one directly (e.g. `github-copilot/claude-sonnet-4.6`, `anthropic/claude-3-5-sonnet`, `ollama/qwen2.5-coder`).
+
+Wire the model into:
+
+- a **Basic LLM Chain** node for simple prompt/response, or
+- an **AI Agent** node with Tools attached (e.g. HTTP Request Tool) for agentic tool-using workflows.
+
+## Step 3: Test it
+
+Run the workflow. For a quick manual check from the n8n host:
+
+```bash
+curl http://<opencode-host-ip>:4010/v1/models \
+  -H "Authorization: Bearer some-long-random-token"
+```
+
+You should see your OpenCode models in OpenAI list format.
+
+## Troubleshooting
+
+- **Model dropdown is empty**: the credential base URL or token is wrong, or the host is unreachable. Verify with the `curl` above from the n8n machine.
+- **Docker on a different machine**: use the OpenCode host's actual LAN IP for `<opencode-host-ip>`. `localhost` and `host.docker.internal` only resolve to the OpenCode host when Docker runs on that same machine.
+- **Connection silently dropped (macOS)**: the macOS Application Firewall will drop connections to the `opencode` binary until you allow it, even with the port open. Allow it under System Settings → Network → Firewall.
+- **Tool calls not firing**: ensure `node` is on `PATH` where OpenCode runs, and that you installed the npm plugin (which includes `mcp-tool-bridge.js`), not just a copied `index.js`.
+
+## Security notes
+
+- Always set `OPENCODE_LLM_PROXY_TOKEN` when binding to `0.0.0.0`.
+- Keep the proxy on your LAN; do not expose port `4010` to the public internet.
+- Restrict inbound access with firewall rules to only the n8n host if possible.
+- See [security.md](../security.md) for full guidance.

--- a/docs/recipes/open-webui.md
+++ b/docs/recipes/open-webui.md
@@ -1,0 +1,55 @@
+# Using opencode-llm-proxy with Open WebUI
+
+## What this gives you
+
+Every model OpenCode has connected appears in Open WebUI's model picker through a single OpenAI-compatible connection — no per-model API keys inside Open WebUI. Streaming works; tool calling support depends on Open WebUI's own feature set.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed
+- A running Open WebUI instance (native or Docker)
+
+## Step 1: Start OpenCode with the proxy
+
+Localhost is fine if Open WebUI runs on the same machine:
+
+```bash
+opencode
+```
+
+For Docker or a remote Open WebUI, bind to all interfaces and set a token:
+
+```bash
+OPENCODE_LLM_PROXY_HOST=0.0.0.0 \
+OPENCODE_LLM_PROXY_TOKEN=some-long-random-token \
+opencode
+```
+
+## Step 2: Configure Open WebUI
+
+1. Settings → Connections → OpenAI API
+2. Set **API Base URL** to `http://127.0.0.1:4010/v1`
+3. Leave API Key blank, or set it to your `OPENCODE_LLM_PROXY_TOKEN`
+4. Save
+
+Running Open WebUI in Docker on the same host? Use `http://host.docker.internal:4010/v1` and start the proxy with `OPENCODE_LLM_PROXY_HOST=0.0.0.0`. On a different host, use the OpenCode host's LAN IP.
+
+## Step 3: Test it
+
+All your OpenCode models should now appear in the model picker. Start a chat and send a message. You can also verify the connection directly:
+
+```bash
+curl http://127.0.0.1:4010/v1/models
+```
+
+## Troubleshooting
+
+- **No models listed**: the base URL is wrong or the proxy is unreachable from the Open WebUI container/host. Confirm with the `curl` above from the same environment Open WebUI runs in.
+- **Docker cannot reach the host**: use `host.docker.internal` (same machine) or the real LAN IP (different machine), and ensure the proxy is bound to `0.0.0.0`.
+- **401 responses**: the API key in Open WebUI must match `OPENCODE_LLM_PROXY_TOKEN`.
+
+## Security notes
+
+- Set a token whenever the proxy is bound beyond `127.0.0.1`.
+- Do not expose the proxy to the public internet.
+- See [security.md](../security.md) for full guidance.

--- a/docs/recipes/zed.md
+++ b/docs/recipes/zed.md
@@ -1,0 +1,61 @@
+# Using opencode-llm-proxy with Zed
+
+## What this gives you
+
+Use any model OpenCode has configured inside the [Zed](https://zed.dev) editor through its OpenAI-compatible provider. Good for chat and inline assistance; tool calling is not Zed's primary path.
+
+## Prerequisites
+
+- OpenCode with `opencode-llm-proxy` installed
+- Zed installed
+
+## Step 1: Start OpenCode with the proxy
+
+```bash
+opencode
+```
+
+The proxy listens on `http://127.0.0.1:4010`.
+
+## Step 2: Configure Zed
+
+Edit `~/.config/zed/settings.json`:
+
+```json
+{
+  "language_models": {
+    "openai": {
+      "api_url": "http://127.0.0.1:4010/v1",
+      "available_models": [
+        {
+          "name": "github-copilot/claude-sonnet-4.6",
+          "display_name": "Claude (OpenCode)",
+          "max_tokens": 8096
+        }
+      ]
+    }
+  }
+}
+```
+
+Add more `available_models` entries for additional OpenCode model IDs.
+
+## Step 3: Test it
+
+Open the assistant panel, pick "Claude (OpenCode)", and send a prompt. Confirm available IDs with:
+
+```bash
+curl http://127.0.0.1:4010/v1/models | jq '.data[].id'
+```
+
+## Troubleshooting
+
+- **Model not listed**: verify the `name` matches a real OpenCode model ID and that the JSON is valid.
+- **No response**: check `curl http://127.0.0.1:4010/health` and that OpenCode is running.
+- **Auth errors**: if `OPENCODE_LLM_PROXY_TOKEN` is set, Zed's OpenAI provider must send it — set it as the API key in Zed's provider settings.
+
+## Security notes
+
+- Localhost binding is appropriate for editor use.
+- Expose on a LAN only with a token and firewall rules.
+- See [security.md](../security.md) for full guidance.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,52 @@
+# Security
+
+opencode-llm-proxy exposes the models OpenCode has configured over a local HTTP endpoint. Treat that endpoint as sensitive: anyone who can reach it can use your provider access and, when tools are attached, trigger tool/function calls.
+
+## Default: localhost only
+
+By default the proxy binds to `127.0.0.1`, so only processes on the same machine can reach it. This is the safest configuration and is recommended whenever the client runs on the same host (editors, local SDK scripts, local agents).
+
+## Use a bearer token when exposing beyond localhost
+
+If you bind to a network interface (`OPENCODE_LLM_PROXY_HOST=0.0.0.0`) for LAN or Docker use, always set a token:
+
+```bash
+OPENCODE_LLM_PROXY_HOST=0.0.0.0 \
+OPENCODE_LLM_PROXY_TOKEN=some-long-random-token \
+opencode
+```
+
+Every request must then send `Authorization: Bearer some-long-random-token`. Use a long, random value and rotate it if it may have leaked.
+
+## Do not expose the proxy to the public internet
+
+The proxy is designed for localhost and trusted LANs. Do not port-forward it, place it on a public IP, or put it behind a public reverse proxy. A token is not a substitute for network isolation.
+
+## Use firewall rules
+
+When exposing on a LAN, restrict inbound access to only the hosts that need it (e.g. your n8n or Open WebUI machine). On macOS, the Application Firewall must be told to allow the `opencode` binary or it will silently drop connections.
+
+## Reverse proxy cautions
+
+If you must front the proxy with a reverse proxy on a trusted network, terminate TLS there, enforce the bearer token, and never forward it from untrusted networks. Avoid caching that could leak responses between users.
+
+## Be careful with tool/function calling
+
+When clients attach tools, the model can request actions that your client then executes (reading files, running commands, HTTP requests). Only enable tools you trust, validate arguments, sandbox side effects, and review any auto-approve settings in agent clients.
+
+## Do not share provider access beyond your intended environment
+
+The whole point of the proxy is reuse of your OpenCode providers. Anyone who can call the proxy is using your GitHub Copilot / Anthropic / Bedrock / etc. access. Keep the audience limited to yourself or your team.
+
+## Do not log bearer tokens
+
+Never log the `Authorization` header or the token value in application logs, reverse-proxy logs, or debugging output. Scrub them from any shared traces or issue reports.
+
+## Checklist
+
+- [ ] Localhost binding unless network access is genuinely required
+- [ ] `OPENCODE_LLM_PROXY_TOKEN` set whenever bound to a network interface
+- [ ] Not reachable from the public internet
+- [ ] Firewall restricts inbound access to known hosts
+- [ ] Tool-using clients are trusted and reviewed
+- [ ] Tokens never written to logs


### PR DESCRIPTION
Adds the documentation and examples from the launch plan, and addresses several open issues.

## What

- **README**: added a **Works with** matrix and a per-SDK/client compatibility matrix (#67), docs nav links, and a hero demo GIF reference.
- **docs/recipes/**: `n8n`, `open-webui`, `langchain`, `continue`, `zed`, `cline`, `custom-agent` — each with what-you-get / prerequisites / start / configure / test / troubleshooting / security.
- **docs/security.md**: LAN exposure, bearer token, firewall, reverse-proxy cautions, tool-calling risk, no token logging, checklist (#68).
- **docs/comparisons.md**: vs LiteLLM / OpenRouter / direct keys / Ollama.
- **docs/examples/open-webui-docker/**: Docker Compose example (compose validated) with `.env.example` and README (#65).
- **docs/examples/n8n/**: importable demo workflow JSON (OpenAI Chat Model → Basic LLM Chain + AI Agent with a Calculator tool) and README (#66).
- **.gitignore**: ignore `promotion.md` and local `docs/promotion-drafts/`.

## Notes

- Based on `feat/parallel-tool-calls` because the docs reference parallel tool calling as a shipped feature; that branch is not yet on `main`.
- `docs/assets/demo.gif` is referenced but not yet produced — the image link will be broken until the GIF is added (storyboard in `docs/assets/README.md`).

## Closes

- Addresses #65, #66, #67, #68 (and initial `docs/recipes/cline.md` for #64).