### PR TITLE
fix(plugin): add V1 default export descriptor to stop legacy loader probing every helper

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+dist/** text eol=lf

--- a/README.md
+++ b/README.md
@@ -535,6 +535,12 @@ Streaming uses OpenCode's `client.event.subscribe()` SSE stream. Text deltas are
 
 ---
 
+## Compatibility
+
+The plugin ships a V1 plugin descriptor (`export default { id, server }`). OpenCode detects it (present in every release checked back to 1.15) and loads the plugin cleanly. On older builds the legacy loader probes every exported function, so you may see a harmless `failed to load plugin ... is not a function` line per worker in the startup log — the proxy still starts and serves normally.
+
+---
+
 ## Limitations
 
 - Media support depends on the selected model's advertised image, audio, video, and PDF/file capabilities

--- a/dist/llm-proxy.js
+++ b/dist/llm-proxy.js
@@ -3389,6 +3389,7 @@ var OpenAIProxyPlugin = async ({ client }) => {
     }
   };
 };
+var index_default = { id: "opencode-llm-proxy", server: OpenAIProxyPlugin };
 export {
   OpenAIProxyPlugin,
   applyAnthropicToolChoice,
@@ -3399,6 +3400,7 @@ export {
   buildToolsMap,
   createProxyFetchHandler,
   createSseQueue,
+  index_default as default,
   extractAssistantText,
   extractGeminiSystemInstruction,
   mapFinishReason,

--- a/index.js
+++ b/index.js
@@ -2770,3 +2770,13 @@ export const OpenAIProxyPlugin = async ({ client }) => {
     },
   }
 }
+
+// V1 plugin descriptor. opencode's plugin loader (readV1Plugin in
+// packages/opencode/src/plugin/shared.ts) prefers a default export of this
+// shape and invokes only `server`. Without it, the loader falls back to the
+// legacy path, which invokes EVERY function-typed export as if it were the
+// plugin — the pure helpers (buildPrompt, mapFinishReason, ...) then throw on
+// the plugin-init argument and every worker logs "failed to load plugin"
+// (see issue #86). Exporting the descriptor keeps all named exports intact
+// for direct imports and tests.
+export default { id: "opencode-llm-proxy", server: OpenAIProxyPlugin }

--- a/index.test.js
+++ b/index.test.js
@@ -3,6 +3,7 @@ import assert from "node:assert/strict"
 import { setTimeout as delay } from "node:timers/promises"
 import { PassThrough } from "node:stream"
 
+import * as mod from "./index.js"
 import {
   createProxyFetchHandler,
   createSseQueue,
@@ -3438,21 +3439,25 @@ describe("mcp-tool-bridge runStdioServer", () => {
 // OpenAIProxyPlugin (plugin entrypoint / server bootstrap)
 // ---------------------------------------------------------------------------
 
-describe("OpenAIProxyPlugin", () => {
-  const STATE_KEY = "__opencodeOpenAIProxyState"
+// Shared Bun.serve mock: the plugin starts its HTTP server via Bun.serve, so
+// tests stub globalThis.Bun and inspect the options it was called with.
+const PROXY_STATE_KEY = "__opencodeOpenAIProxyState"
 
-  function withMockedBun(serve, run) {
-    const savedBun = globalThis.Bun
-    delete globalThis[STATE_KEY]
-    globalThis.Bun = { serve }
-    return Promise.resolve()
-      .then(run)
-      .finally(() => {
-        if (savedBun === undefined) delete globalThis.Bun
-        else globalThis.Bun = savedBun
-        delete globalThis[STATE_KEY]
-      })
-  }
+function withMockedBun(serve, run) {
+  const savedBun = globalThis.Bun
+  delete globalThis[PROXY_STATE_KEY]
+  globalThis.Bun = { serve }
+  return Promise.resolve()
+    .then(run)
+    .finally(() => {
+      if (savedBun === undefined) delete globalThis.Bun
+      else globalThis.Bun = savedBun
+      delete globalThis[PROXY_STATE_KEY]
+    })
+}
+
+describe("OpenAIProxyPlugin", () => {
+  const STATE_KEY = PROXY_STATE_KEY
 
   it("starts a Bun server and records it in global state", async () => {
     const calls = []
@@ -3587,3 +3592,42 @@ describe("OpenAIProxyPlugin", () => {
     )
   })
 })
+
+// ---------------------------------------------------------------------------
+// V1 plugin descriptor (default export)
+// ---------------------------------------------------------------------------
+
+describe("V1 plugin default export", () => {
+  it("exposes a { id, server } descriptor so opencode's loader skips the legacy fallback", async () => {
+    assert.ok(mod.default, "index.js must have a default export")
+    assert.equal(typeof mod.default, "object", "default export must be a V1 descriptor object")
+    assert.equal(mod.default.id, "opencode-llm-proxy")
+    assert.equal(typeof mod.default.server, "function", "descriptor.server must be the plugin factory")
+  })
+
+  it("descriptor.server starts the proxy when invoked, like the loader would", async () => {
+    const calls = []
+
+    await withMockedBun(
+      (opts) => {
+        calls.push(opts)
+        return { stopped: false }
+      },
+      async () => {
+        process.env.OPENCODE_LLM_PROXY_HOST = "127.0.0.1"
+        process.env.OPENCODE_LLM_PROXY_PORT = "4997"
+        try {
+          const result = await mod.default.server({ client: createClient() })
+
+          assert.equal(typeof result["chat.params"], "function")
+          assert.equal(calls.length, 1)
+          assert.equal(calls[0].port, 4997)
+        } finally {
+          delete process.env.OPENCODE_LLM_PROXY_HOST
+          delete process.env.OPENCODE_LLM_PROXY_PORT
+        }
+      },
+    )
+  })
+})
+


### PR DESCRIPTION
Fixes #86.

## What

Adds a V1 plugin descriptor as the default export of `index.js` (and the rebuilt `dist/llm-proxy.js`):

```js
export default { id: "opencode-llm-proxy", server: OpenAIProxyPlugin }
```

All 28 named exports stay untouched, so direct imports and the test suite are unaffected.

## Why

Without a default export, opencode's loader takes the legacy path (`getLegacyPlugins`), which invokes **every function-typed export** as if it were the plugin factory. The pure helpers (`buildPrompt`, `mapFinishReason`, …) throw on the plugin-init argument, so every worker logs `failed to load plugin` (`messages.filter` / `finish.includes` / `messages.map is not a function` — whichever helper it reaches). The proxy still serves today only because `OpenAIProxyPlugin` happens to run first in `Object.values` order and `Bun.serve` fires as a side effect before any helper throws — i.e. it works by iteration-order luck.

With the descriptor present, `readV1Plugin` (packages/opencode/src/plugin/shared.ts) detects it and invokes **only** `server`.

## Verification

**Shipped-artifact path (not a wrapper):** `npm pack` from this branch → installed the tarball into opencode's package cache → registered bare-name (`"plugin": ["opencode-llm-proxy"]`) in a scratch project → booted `opencode serve` (1.18.18, current latest) and forced instance creation:

- `failed to load plugin` lines: **0** (previously 1 per worker on every boot)
- proxy came up on its configured port; `GET /v1/models` → **HTTP 200** with the model list

**Unit suite:** 232/232 pass (230 baseline + 2 new), eslint clean. New tests assert the descriptor shape **and** invoke `descriptor.server({ client })` under the existing mocked-`Bun` fixture (hoisted to a shared `withMockedBun` helper) to prove the proxy actually boots through it.

## Older-opencode behavior (no regression)

- `readV1Plugin` exists in every opencode release I checked back to **v1.15.0**, so the V1 path covers everything reasonably current.
- On loaders that predate it, the legacy path is still safe: `getServerPlugin` explicitly recognizes `{ server }` objects (index.ts L88–93) — the descriptor is treated as a plugin whose `server` is `OpenAIProxyPlugin`, and the plugin's existing `state.started` guard makes the second invocation a no-op returning `{}`. Helper-probe log noise on those old builds is unchanged from today.

## Extras

- `.gitattributes` with `dist/** text eol=lf` — the committed bundle is regenerated by `prepack`, so keeping it LF-only avoids whole-file churn on rebuilds.
- README gains a short **Compatibility** note (clean load on current opencode; harmless per-worker log line on very old builds) to pre-empt "still broken on 1.14" follow-ups.
